### PR TITLE
refactor: filter segments in place

### DIFF
--- a/internal/logcrunch/compaction.go
+++ b/internal/logcrunch/compaction.go
@@ -77,13 +77,14 @@ func PackSegments(segments []lrdb.GetLogSegmentsForCompactionRow, estimatedRecor
 }
 
 func filterSegments(segs []lrdb.GetLogSegmentsForCompactionRow) []lrdb.GetLogSegmentsForCompactionRow {
-	out := make([]lrdb.GetLogSegmentsForCompactionRow, 0, len(segs))
+	j := 0
 	for _, s := range segs {
 		if s.RecordCount > 0 {
-			out = append(out, s)
+			segs[j] = s
+			j++
 		}
 	}
-	return out
+	return segs[:j]
 }
 
 const msPerDay int64 = 86_400_000


### PR DESCRIPTION
## Summary
- avoid extra allocation by filtering log compaction segments in place

## Testing
- `make check` *(fails: duckdb-images/Dockerfile missing license header)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c2ca83dfc8321b9a6575be71a0147