### PR TITLE
Use buildx imagetools for DuckDB manifests

### DIFF
--- a/.github/workflows/duckdb-sdk.yml
+++ b/.github/workflows/duckdb-sdk.yml
@@ -87,23 +87,15 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
+      - uses: docker/setup-buildx-action@v3
 
       - name: Create and push multi-arch manifest
         run: |
-          # Remove any existing manifests to avoid conflicts
-          docker manifest rm public.ecr.aws/cardinalhq.io/duckdb-sdk:${{ inputs.duckdb_version }} 2>/dev/null || true
-          docker manifest rm public.ecr.aws/cardinalhq.io/duckdb-sdk:latest 2>/dev/null || true
-
-          # Create and push versioned manifest using --amend to handle existing manifest lists
-          docker manifest create --amend \
-            public.ecr.aws/cardinalhq.io/duckdb-sdk:${{ inputs.duckdb_version }} \
+          docker buildx imagetools create \
+            --tag public.ecr.aws/cardinalhq.io/duckdb-sdk:${{ inputs.duckdb_version }} \
             public.ecr.aws/cardinalhq.io/duckdb-sdk:${{ inputs.duckdb_version }}-amd64 \
             public.ecr.aws/cardinalhq.io/duckdb-sdk:${{ inputs.duckdb_version }}-arm64
-          docker manifest push public.ecr.aws/cardinalhq.io/duckdb-sdk:${{ inputs.duckdb_version }}
-
-          # Create and push latest manifest using --amend to handle existing manifest lists
-          docker manifest create --amend \
-            public.ecr.aws/cardinalhq.io/duckdb-sdk:latest \
+          docker buildx imagetools create \
+            --tag public.ecr.aws/cardinalhq.io/duckdb-sdk:latest \
             public.ecr.aws/cardinalhq.io/duckdb-sdk:latest-amd64 \
             public.ecr.aws/cardinalhq.io/duckdb-sdk:latest-arm64
-          docker manifest push public.ecr.aws/cardinalhq.io/duckdb-sdk:latest


### PR DESCRIPTION
## Summary
- use `docker buildx imagetools create` to publish versioned and latest DuckDB SDK manifests
- drop manual manifest removal and setup buildx in manifest job

## Testing
- `make test license-check`


------
https://chatgpt.com/codex/tasks/task_e_689ec4d8cea48321bfb00b618de07a53