### PR TITLE
Fix Unbounded SQL Queries in Metric Segment Operations

### DIFF
--- a/cmd/rollup_metrics.go
+++ b/cmd/rollup_metrics.go
@@ -127,7 +127,7 @@ func metricRollupItemDo(
 	if !ok {
 		return WorkResultSuccess, fmt.Errorf("invalid time range in work item: %v", inf.TsRange())
 	}
-	sourceRows, err := mdb.GetMetricSegs(ctx, lrdb.GetMetricSegsParams{
+	sourceRows, err := mdb.GetMetricSegsForRollup(ctx, lrdb.GetMetricSegsForRollupParams{
 		OrganizationID: inf.OrganizationID(),
 		InstanceNum:    inf.InstanceNum(),
 		Dateint:        inf.Dateint(),
@@ -144,7 +144,7 @@ func metricRollupItemDo(
 		return WorkResultSuccess, nil
 	}
 
-	currentRows, err := mdb.GetMetricSegs(ctx, lrdb.GetMetricSegsParams{
+	currentRows, err := mdb.GetMetricSegsForRollup(ctx, lrdb.GetMetricSegsForRollupParams{
 		OrganizationID: inf.OrganizationID(),
 		InstanceNum:    inf.InstanceNum(),
 		Dateint:        inf.Dateint(),

--- a/internal/metriccompaction/compaction.go
+++ b/internal/metriccompaction/compaction.go
@@ -118,7 +118,7 @@ func doCompactItem(
 			FrequencyMs:     inf.FrequencyMs(),
 			StartTs:         st.Time.UTC().UnixMilli(),
 			EndTs:           et.Time.UTC().UnixMilli(),
-			MaxFileSize:     targetFileSize * 19 / 10, // Filter out files larger than 1.9x target (won't be compacted)
+			MaxFileSize:     targetFileSize * 9 / 10, // Only include files < 90% of target (larger files are fine as-is)
 			CursorCreatedAt: cursorCreatedAt,          // Cursor for pagination
 			Maxrows:         maxRowsLimit,             // Safety limit for compaction batch
 		})

--- a/internal/metriccompaction/compaction.go
+++ b/internal/metriccompaction/compaction.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"time"
 
 	"github.com/cardinalhq/lakerunner/internal/awsclient"
 	"github.com/cardinalhq/lakerunner/internal/awsclient/s3helper"
@@ -90,36 +91,102 @@ func doCompactItem(
 		return WorkResultSuccess, fmt.Errorf("invalid time range in work item: %v", inf.TsRange())
 	}
 
-	inRows, err := mdb.GetMetricSegs(ctx, lrdb.GetMetricSegsParams{
-		OrganizationID: inf.OrganizationID(),
-		InstanceNum:    inf.InstanceNum(),
-		Dateint:        inf.Dateint(),
-		FrequencyMs:    inf.FrequencyMs(),
-		StartTs:        st.Time.UTC().UnixMilli(),
-		EndTs:          et.Time.UTC().UnixMilli(),
-	})
-	if err != nil {
-		ll.Error("Failed to get current metric segments", slog.Any("error", err))
-		return WorkResultTryAgainLater, err
-	}
+	const maxRowsLimit = 1000
+	totalBatchesProcessed := 0
+	totalSegmentsProcessed := 0
+	cursorCreatedAt := time.Time{} // Start from beginning (zero time)
 
-	if len(inRows) == 0 {
-		ll.Info("No input rows to compact, skipping work item")
-		return WorkResultSuccess, nil
-	}
+	// Loop until we've processed all available segments
+	for {
+		// Check if context is cancelled before starting next batch
+		if ctx.Err() != nil {
+			ll.Info("Context cancelled, stopping compaction loop - will retry to continue",
+				slog.Int("processedBatches", totalBatchesProcessed),
+				slog.Int("processedSegments", totalSegmentsProcessed),
+				slog.Any("error", ctx.Err()))
+			return WorkResultTryAgainLater, nil
+		}
 
-	if !ShouldCompactMetrics(inRows) {
-		ll.Info("No need to compact metrics, skipping work item", slog.Int("rowCount", len(inRows)))
-		return WorkResultSuccess, nil
-	}
+		ll.Info("Querying for metric segments to compact",
+			slog.Int("batch", totalBatchesProcessed+1),
+			slog.Time("cursorCreatedAt", cursorCreatedAt))
 
-	err = compactInterval(ctx, ll, mdb, tmpdir, inf, profile, s3client, inRows, rpfEstimate)
-	if err != nil {
-		ll.Error("Failed to compact interval", slog.Any("error", err))
-		return WorkResultTryAgainLater, err
-	}
+		inRows, err := mdb.GetMetricSegsForCompaction(ctx, lrdb.GetMetricSegsForCompactionParams{
+			OrganizationID:  inf.OrganizationID(),
+			InstanceNum:     inf.InstanceNum(),
+			Dateint:         inf.Dateint(),
+			FrequencyMs:     inf.FrequencyMs(),
+			StartTs:         st.Time.UTC().UnixMilli(),
+			EndTs:           et.Time.UTC().UnixMilli(),
+			MaxFileSize:     targetFileSize * 19 / 10, // Filter out files larger than 1.9x target (won't be compacted)
+			CursorCreatedAt: cursorCreatedAt,          // Cursor for pagination
+			Maxrows:         maxRowsLimit,             // Safety limit for compaction batch
+		})
+		if err != nil {
+			ll.Error("Failed to get current metric segments", slog.Any("error", err))
+			return WorkResultTryAgainLater, err
+		}
 
-	return WorkResultSuccess, nil
+		// No more segments to process
+		if len(inRows) == 0 {
+			if totalBatchesProcessed == 0 {
+				ll.Info("No input rows to compact, skipping work item")
+			} else {
+				ll.Info("Finished processing all compaction batches",
+					slog.Int("totalBatches", totalBatchesProcessed),
+					slog.Int("totalSegments", totalSegmentsProcessed))
+			}
+			return WorkResultSuccess, nil
+		}
+
+		ll.Info("Processing compaction batch",
+			slog.Int("segmentCount", len(inRows)),
+			slog.Int("batch", totalBatchesProcessed+1))
+
+		// Update cursor to last created_at in this batch to ensure forward progress
+		if len(inRows) > 0 {
+			cursorCreatedAt = inRows[len(inRows)-1].CreatedAt
+		}
+
+		// Check if this batch needs compaction
+		if !ShouldCompactMetrics(inRows) {
+			ll.Info("No need to compact metrics in this batch", slog.Int("rowCount", len(inRows)))
+
+			// If we didn't hit the limit, we've seen all segments
+			if len(inRows) < maxRowsLimit {
+				if totalBatchesProcessed == 0 {
+					ll.Info("No segments need compaction")
+				}
+				return WorkResultSuccess, nil
+			}
+			// Continue to next batch without processing - cursor already advanced
+			totalBatchesProcessed++
+			continue
+		}
+
+		// Process this batch
+		err = compactInterval(ctx, ll, mdb, tmpdir, inf, profile, s3client, inRows, rpfEstimate)
+		if err != nil {
+			ll.Error("Failed to compact interval", slog.Any("error", err))
+			return WorkResultTryAgainLater, err
+		}
+
+		totalBatchesProcessed++
+		totalSegmentsProcessed += len(inRows)
+
+		// If we didn't hit the limit, we've processed all available segments
+		if len(inRows) < maxRowsLimit {
+			ll.Info("Completed all compaction batches",
+				slog.Int("totalBatches", totalBatchesProcessed),
+				slog.Int("totalSegments", totalSegmentsProcessed))
+			return WorkResultSuccess, nil
+		}
+
+		// Continue to next batch - cursor already advanced
+		ll.Info("Batch completed, checking for more segments",
+			slog.Int("processedSegments", len(inRows)),
+			slog.Time("nextCursor", cursorCreatedAt))
+	}
 }
 
 func ShouldCompactMetrics(rows []lrdb.MetricSeg) bool {

--- a/lrdb/metric_seg.sql.go
+++ b/lrdb/metric_seg.sql.go
@@ -19,11 +19,7 @@ WHERE
   dateint = $2 AND
   frequency_ms = $3 AND
   instance_num = $4
-  AND (
-    ($5::BIGINT = 0 AND $6::BIGINT = 0)
-    OR
-    (ts_range && int8range($5, $6, '[)'))
-  )
+  AND ts_range && int8range($5, $6, '[)')
 ORDER BY
   ts_range
 `

--- a/lrdb/querier.go
+++ b/lrdb/querier.go
@@ -36,7 +36,8 @@ type Querier interface {
 	GetExemplarTracesByService(ctx context.Context, arg GetExemplarTracesByServiceParams) ([]ExemplarTrace, error)
 	GetExemplarTracesCreatedAfter(ctx context.Context, ts time.Time) ([]ExemplarTrace, error)
 	GetLogSegmentsForCompaction(ctx context.Context, arg GetLogSegmentsForCompactionParams) ([]GetLogSegmentsForCompactionRow, error)
-	GetMetricSegs(ctx context.Context, arg GetMetricSegsParams) ([]MetricSeg, error)
+	GetMetricSegsForCompaction(ctx context.Context, arg GetMetricSegsForCompactionParams) ([]MetricSeg, error)
+	GetMetricSegsForRollup(ctx context.Context, arg GetMetricSegsForRollupParams) ([]MetricSeg, error)
 	GetSpanInfoByFingerprint(ctx context.Context, arg GetSpanInfoByFingerprintParams) (GetSpanInfoByFingerprintRow, error)
 	InqueueJournalDelete(ctx context.Context, arg InqueueJournalDeleteParams) error
 	InqueueJournalUpsert(ctx context.Context, arg InqueueJournalUpsertParams) (bool, error)

--- a/lrdb/queries/metric_seg.sql
+++ b/lrdb/queries/metric_seg.sql
@@ -30,7 +30,22 @@ VALUES (
   @published
 );
 
--- name: GetMetricSegs :many
+-- name: GetMetricSegsForCompaction :many
+SELECT *
+FROM metric_seg
+WHERE
+  organization_id = @organization_id AND
+  dateint = @dateint AND
+  frequency_ms = @frequency_ms AND
+  instance_num = @instance_num
+  AND ts_range && int8range(@start_ts, @end_ts, '[)')
+  AND file_size <= @max_file_size
+  AND created_at > @cursor_created_at
+ORDER BY
+  created_at
+LIMIT @maxrows;
+
+-- name: GetMetricSegsForRollup :many
 SELECT *
 FROM metric_seg
 WHERE

--- a/lrdb/queries/metric_seg.sql
+++ b/lrdb/queries/metric_seg.sql
@@ -38,11 +38,7 @@ WHERE
   dateint = @dateint AND
   frequency_ms = @frequency_ms AND
   instance_num = @instance_num
-  AND (
-    (@start_ts::BIGINT = 0 AND @end_ts::BIGINT = 0)
-    OR
-    (ts_range && int8range(@start_ts, @end_ts, '[)'))
-  )
+  AND ts_range && int8range(@start_ts, @end_ts, '[)')
 ORDER BY
   ts_range;
 

--- a/promql/stream_sort_test.go
+++ b/promql/stream_sort_test.go
@@ -58,14 +58,14 @@ func isSortedAsc(xs []tsItem) bool {
 	return true
 }
 
-func isSortedDesc(xs []tsItem) bool {
-	for i := 1; i < len(xs); i++ {
-		if xs[i-1].ts < xs[i].ts {
-			return false
-		}
-	}
-	return true
-}
+// func isSortedDesc(xs []tsItem) bool {
+// 	for i := 1; i < len(xs); i++ {
+// 		if xs[i-1].ts < xs[i].ts {
+// 			return false
+// 		}
+// 	}
+// 	return true
+// }
 
 // --- tests ---
 


### PR DESCRIPTION
## Summary

This PR addresses critical unbounded SQL query vulnerabilities in metric segment operations that could lead to performance issues and potential system instability. The changes implement safe batching with cursor-based pagination and context cancellation handling.

## Problem

The GetMetricSegs query had several dangerous patterns:
- Unbounded results: Could return unlimited rows without LIMIT constraints
- Bypass condition: (@start_ts = 0 AND @end_ts = 0) allowed completely unfiltered queries
- Potential deadlocks: Batching without cursors could loop infinitely on non-compactable segments
- Missing context handling: Long-running compaction loops didn't respect cancellation

## Solution

1. Split Query Methods by Use Case

- GetMetricSegsForCompaction: Bounded with size filters and row limits for safe compaction
- GetMetricSegsForRollup: Unbounded for rollup operations that legitimately need all data

2. Added Safety Constraints

- File size filter: file_size <= 90% of targetFileSize (filters out large files that won't be compacted)
- Row limit: LIMIT 1000 per batch to prevent runaway queries
- Removed bypass condition: Eliminated dangerous start_ts=0, end_ts=0 escape hatch

3. Cursor-Based Pagination

- Pagination key: created_at > @cursor_created_at ensures forward progress
- Deadlock prevention: Even non-compactable segments advance the cursor
- Complete coverage: All segments are eventually processed across batches

4. Internal Batching Loop

- Progress preservation: Each completed batch is committed before continuing
- Context safety: Respects cancellation and returns WorkResultTryAgainLater for resume