### PR TITLE
Use compound cursor pagination for log and metric compaction

### DIFF
--- a/lrdb/metric_seg.sql.go
+++ b/lrdb/metric_seg.sql.go
@@ -22,10 +22,10 @@ WHERE
   instance_num = $4
   AND ts_range && int8range($5, $6, '[)')
   AND file_size <= $7
-  AND created_at > $8
+  AND (created_at, segment_id) > ($8, $9::bigint)
 ORDER BY
-  created_at
-LIMIT $9
+  created_at, segment_id
+LIMIT $10
 `
 
 type GetMetricSegsForCompactionParams struct {
@@ -37,6 +37,7 @@ type GetMetricSegsForCompactionParams struct {
 	EndTs           int64     `json:"end_ts"`
 	MaxFileSize     int64     `json:"max_file_size"`
 	CursorCreatedAt time.Time `json:"cursor_created_at"`
+	CursorSegmentID int64     `json:"cursor_segment_id"`
 	Maxrows         int32     `json:"maxrows"`
 }
 
@@ -50,6 +51,7 @@ func (q *Queries) GetMetricSegsForCompaction(ctx context.Context, arg GetMetricS
 		arg.EndTs,
 		arg.MaxFileSize,
 		arg.CursorCreatedAt,
+		arg.CursorSegmentID,
 		arg.Maxrows,
 	)
 	if err != nil {

--- a/lrdb/migrations/1755324336_add_created_at_to_log_seg.down.sql
+++ b/lrdb/migrations/1755324336_add_created_at_to_log_seg.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_log_seg_created_at_segment_id;
+ALTER TABLE log_seg DROP COLUMN IF EXISTS created_at;

--- a/lrdb/migrations/1755324336_add_created_at_to_log_seg.up.sql
+++ b/lrdb/migrations/1755324336_add_created_at_to_log_seg.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE log_seg ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Create index for efficient pagination within each partition
+-- Since the table is partitioned by organization_id and dateint, we only need instance_num, created_at, segment_id
+CREATE INDEX idx_log_seg_created_at_segment_id ON log_seg (instance_num, created_at, segment_id);

--- a/lrdb/models.go
+++ b/lrdb/models.go
@@ -167,6 +167,7 @@ type LogSeg struct {
 	IngestDateint  int32                     `json:"ingest_dateint"`
 	TsRange        pgtype.Range[pgtype.Int8] `json:"ts_range"`
 	CreatedBy      CreatedBy                 `json:"created_by"`
+	CreatedAt      time.Time                 `json:"created_at"`
 }
 
 type MetricSeg struct {

--- a/lrdb/queries/log_seg.sql
+++ b/lrdb/queries/log_seg.sql
@@ -31,14 +31,18 @@ SELECT
   upper(ts_range)::bigint AS end_ts,
   file_size,
   record_count,
-  ingest_dateint
+  ingest_dateint,
+  created_at
 FROM log_seg
 WHERE organization_id = @organization_id
   AND dateint         = @dateint
   AND instance_num    = @instance_num
   AND file_size > 0
   AND record_count > 0
-ORDER BY lower(ts_range);
+  AND file_size <= @max_file_size
+  AND (created_at, segment_id) > (@cursor_created_at, @cursor_segment_id::bigint)
+ORDER BY created_at, segment_id
+LIMIT @maxrows;
 
 -- name: CompactLogSegments :exec
 WITH

--- a/lrdb/queries/metric_seg.sql
+++ b/lrdb/queries/metric_seg.sql
@@ -40,9 +40,9 @@ WHERE
   instance_num = @instance_num
   AND ts_range && int8range(@start_ts, @end_ts, '[)')
   AND file_size <= @max_file_size
-  AND created_at > @cursor_created_at
+  AND (created_at, segment_id) > (@cursor_created_at, @cursor_segment_id::bigint)
 ORDER BY
-  created_at
+  created_at, segment_id
 LIMIT @maxrows;
 
 -- name: GetMetricSegsForRollup :many

--- a/lrdb/sqlc.yaml
+++ b/lrdb/sqlc.yaml
@@ -37,6 +37,8 @@ sql:
           - {db_type: "jsonb", go_type: {type: "map[string]any"}}
           - {db_type: "timestamptz", go_type: {type: "time.Time"}}
           - {db_type: "timestamptz", nullable: true, go_type: {type: "*time.Time"}}
+          - {db_type: "pg_catalog.timestamptz", go_type: {type: "time.Time"}}
+          - {db_type: "pg_catalog.timestamptz", nullable: true, go_type: {type: "*time.Time"}}
           - {db_type: "interval", go_type: {import: "time", type: "Duration"}}
           - {db_type: "uuid", go_type: {import: "github.com/google/uuid", type: "UUID"}}
           - {db_type: "pg_catalog.float8", nullable: true, go_type: {type: "*float64"}}


### PR DESCRIPTION
  Updates both log and metric compaction to use `(created_at, segment_id)` compound cursors instead of just `created_at`. This prevents missing
  rows when multiple segments have identical timestamps from batch inserts, making compaction more robust in production.

  - Added `created_at` column to `log_seg` table with migration
  - Updated SQL queries to use compound cursor pagination
  - Modified compaction logic to track both cursor values
  - Ensures deterministic ordering using Snowflake-style segment IDs