### PR TITLE
Smaller interruptable units

### DIFF
--- a/cmd/ingest_traces_cmd.go
+++ b/cmd/ingest_traces_cmd.go
@@ -16,14 +16,12 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -32,8 +30,6 @@ import (
 	"github.com/cardinalhq/lakerunner/internal/awsclient/s3helper"
 	"github.com/cardinalhq/lakerunner/internal/helpers"
 	"github.com/cardinalhq/lakerunner/internal/storageprofile"
-	"github.com/cardinalhq/lakerunner/internal/tracecompaction"
-	"github.com/cardinalhq/lakerunner/lockmgr"
 	"github.com/cardinalhq/lakerunner/lrdb"
 )
 
@@ -274,14 +270,14 @@ func convertTracesFileIfSupported(ll *slog.Logger, tmpfilename, tmpdir, bucket, 
 func queueTraceCompactionForSlot(ctx context.Context, mdb lrdb.StoreFull, inf lrdb.Inqueue, slotID int, dateint int32, hourAlignedTS int64) error {
 
 	return mdb.WorkQueueAdd(ctx, lrdb.WorkQueueAddParams{
-		OrgID:     inf.OrganizationID,
-		Instance:  inf.InstanceNum,
-		Signal:    lrdb.SignalEnumTraces,
-		Action:    lrdb.ActionEnumCompact,
-		Dateint:   dateint,
-		Frequency: -1,
-		SlotID:    int32(slotID),
-		TsRange:   qmcFromInqueue(inf, 3600000, hourAlignedTS).TsRange,
+		OrgID:      inf.OrganizationID,
+		Instance:   inf.InstanceNum,
+		Signal:     lrdb.SignalEnumTraces,
+		Action:     lrdb.ActionEnumCompact,
+		Dateint:    dateint,
+		Frequency:  -1,
+		SlotID:     int32(slotID),
+		TsRange:    qmcFromInqueue(inf, 3600000, hourAlignedTS).TsRange,
 		RunnableAt: time.Now().UTC().Add(5 * time.Minute),
 	})
 }

--- a/cmd/ingesttraces/otel_proto.go
+++ b/cmd/ingesttraces/otel_proto.go
@@ -216,12 +216,12 @@ func ConvertProtoFile(tmpfilename, tmpdir, bucket, objectID string, rpfEstimate 
 			// Include timestamp range information in the result
 			timestampRange := slotTimestampRanges[slot]
 			allResults = append(allResults, TraceFileResult{
-				FileName:      res.FileName,
-				RecordCount:   res.RecordCount,
-				FileSize:      res.FileSize,
-				SlotID:        slot,
-				MinTimestamp:  timestampRange.MinTimestamp,
-				MaxTimestamp:  timestampRange.MaxTimestamp,
+				FileName:     res.FileName,
+				RecordCount:  res.RecordCount,
+				FileSize:     res.FileSize,
+				SlotID:       slot,
+				MinTimestamp: timestampRange.MinTimestamp,
+				MaxTimestamp: timestampRange.MaxTimestamp,
 			})
 		}
 	}
@@ -241,10 +241,10 @@ type SlotTimestampRange struct {
 
 // TraceFileResult contains information about a converted trace file
 type TraceFileResult struct {
-	FileName      string
-	RecordCount   int64
-	FileSize      int64
-	SlotID        int
-	MinTimestamp  int64
-	MaxTimestamp  int64
+	FileName     string
+	RecordCount  int64
+	FileSize     int64
+	SlotID       int
+	MinTimestamp int64
+	MaxTimestamp int64
 }

--- a/cmd/operation_id.go
+++ b/cmd/operation_id.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"strings"
+)
+
+// generateOperationID creates a unique operation ID for tracking atomic operations
+// Format: randomBase32
+func generateOperationID(index int) string {
+	return generateShortID()
+}
+
+// generateShortID creates a short random base32 ID for operation tracking
+func generateShortID() string {
+	b := make([]byte, 5) // 5 bytes = 8 base32 chars
+	_, _ = rand.Read(b)  // errors from rand.Read are rare and not critical for operation IDs
+	return strings.TrimRight(base32.StdEncoding.EncodeToString(b), "=")
+}

--- a/cmd/pack_segment.go
+++ b/cmd/pack_segment.go
@@ -261,9 +261,16 @@ func packSegment(
 	dateint int32,
 	instanceNum int16,
 ) error {
+	// ll already has operationID from caller
 	if len(group) < 2 {
+		ll.Info("Atomic operation skipped - insufficient segments for compaction",
+			slog.Int("segmentCount", len(group)),
+			slog.String("reason", "need at least 2 segments"))
 		return nil
 	}
+
+	ll.Debug("Starting atomic compaction - downloading and opening segments",
+		slog.Int("segmentCount", len(group)))
 
 	fetcher := objectFetcherAdapter{s3Client: s3Client}
 	open := fileOpenerAdapter{}
@@ -271,15 +278,22 @@ func packSegment(
 
 	opened, err := downloadAndOpen(ctx, sp, dateint, group, tmpdir, sp.Bucket, fetcher, open)
 	if err != nil {
+		ll.Error("Atomic operation failed during segment download",
+			slog.Any("error", err),
+			slog.Int("segmentCount", len(group)))
 		return err
 	}
 
 	if len(opened) < 2 {
-		ll.Info("Group has fewer than 2 usable segments; skipping",
-			slog.Int("requestedGroupSize", len(group)),
-			slog.Int("usableSegments", len(opened)))
+		ll.Info("Atomic operation skipped - insufficient usable segments after download",
+			slog.Int("requestedSegmentCount", len(group)),
+			slog.Int("usableSegmentCount", len(opened)),
+			slog.String("reason", "some segments may be missing from S3"))
 		return nil
 	}
+
+	ll.Debug("Successfully downloaded segments, beginning compaction",
+		slog.Int("segmentCount", len(opened)))
 
 	handles := make([]*filecrunch.FileHandle, 0, len(opened))
 	usedSegs := make([]lrdb.GetLogSegmentsForCompactionRow, 0, len(opened))
@@ -297,14 +311,19 @@ func packSegment(
 		}
 	}()
 
+	ll.Debug("Merging schemas from downloaded segments")
 	nodes, err := mergeNodes(handles)
 	if err != nil {
-		ll.Error("Error merging nodes", slog.String("error", err.Error()))
+		ll.Error("Atomic operation failed during schema merge",
+			slog.Any("error", err))
 		return err
 	}
 
+	ll.Debug("Creating writer for compacted output")
 	w, err := wf.NewWriter("logcompact", tmpdir, nodes, 0)
 	if err != nil {
+		ll.Error("Atomic operation failed during writer creation",
+			slog.Any("error", err))
 		return err
 	}
 	writerClosed := false
@@ -314,29 +333,42 @@ func packSegment(
 		}
 	}()
 
+	ll.Debug("Copying and compacting data from all segments")
 	_, err = copyAll(ctx, open, w, handles)
 	if err != nil {
+		ll.Error("Atomic operation failed during data copying",
+			slog.Any("error", err))
 		return err
 	}
 
 	writeResults, err := w.Close()
 	writerClosed = true
 	if err != nil {
+		ll.Error("Atomic operation failed during file finalization",
+			slog.Any("error", err))
 		return err
 	}
 	if len(writeResults) == 0 {
-		ll.Info("No records written, skipping upload")
+		ll.Info("Atomic operation skipped - no records to write",
+			slog.String("reason", "all input segments were empty"))
 		return nil
 	}
 	writeResult := writeResults[0]
 
+	ll.Debug("Validating compacted file before upload")
 	stats := statsFor(usedSegs)
 	if writeResult.RecordCount != stats.CountRecords {
+		ll.Error("Atomic operation failed during validation",
+			slog.String("error", "record count mismatch"),
+			slog.Int64("expected", stats.CountRecords),
+			slog.Int64("actual", writeResult.RecordCount))
 		return fmt.Errorf("record count mismatch: expected=%d actual=%d", stats.CountRecords, writeResult.RecordCount)
 	}
 
 	fi, err := os.Stat(writeResult.FileName)
 	if err != nil {
+		ll.Error("Atomic operation failed during file stat",
+			slog.Any("error", err))
 		return err
 	}
 
@@ -345,19 +377,22 @@ func packSegment(
 		sp.OrganizationID, sp.CollectorName, dateint, s3helper.HourFromMillis(stats.FirstTS), newSegmentID, "logs",
 	)
 
-	ll.Info("Uploading new file to S3",
-		slog.Int64("size", fi.Size()),
+	ll.Info("Uploading compacted file to S3 - point of no return approaching",
+		slog.Int64("fileSize", fi.Size()),
 		slog.String("objectID", newObjectID),
 		slog.Int64("segmentID", newSegmentID),
-		slog.Int64("firstTS", stats.FirstTS),
-		slog.Int64("lastTS", stats.LastTS),
 		slog.Int64("recordCount", writeResult.RecordCount),
-		slog.Int64("fileSize", fi.Size()),
-	)
+		slog.Int("segmentCount", len(usedSegs)))
 
 	if err := s3helper.UploadS3Object(ctx, s3Client, sp.Bucket, newObjectID, writeResult.FileName); err != nil {
+		ll.Error("Atomic operation failed during S3 upload - no changes made",
+			slog.Any("error", err),
+			slog.String("objectID", newObjectID))
 		return err
 	}
+
+	ll.Debug("S3 upload successful, updating database index - CRITICAL SECTION",
+		slog.String("objectID", newObjectID))
 
 	if err := mdb.CompactLogSegments(ctx, lrdb.CompactLogSegmentsParams{
 		OrganizationID: sp.OrganizationID,
@@ -372,14 +407,50 @@ func packSegment(
 		OldSegmentIds:  segmentIDsFrom(usedSegs),
 		CreatedBy:      lrdb.CreatedByCompact,
 	}); err != nil {
+		ll.Error("Database update failed after S3 upload",
+			slog.Any("error", err),
+			slog.String("objectID", newObjectID),
+			slog.Int64("segmentID", newSegmentID),
+			slog.String("bucket", sp.Bucket))
+
+		// Best effort cleanup - try to delete the uploaded file
+		ll.Debug("Attempting to cleanup orphaned S3 object")
+		if cleanupErr := s3helper.DeleteS3Object(ctx, s3Client, sp.Bucket, newObjectID); cleanupErr != nil {
+			ll.Error("Failed to cleanup orphaned S3 object - manual cleanup required",
+				slog.Any("error", cleanupErr),
+				slog.String("objectID", newObjectID),
+				slog.String("bucket", sp.Bucket))
+		} else {
+			ll.Info("Successfully cleaned up orphaned S3 object")
+		}
 		return err
 	}
 
+	ll.Info("Atomic operation committed successfully - database updated, segments swapped",
+		slog.Int("segmentCount", len(usedSegs)),
+		slog.Int64("segmentID", newSegmentID),
+		slog.Int64("recordCount", writeResult.RecordCount),
+		slog.Int64("fileSize", fi.Size()),
+		slog.String("objectID", newObjectID))
+
+	// Schedule old files for deletion (best effort)
+	ll.Debug("Scheduling old segment files for background deletion",
+		slog.Int("fileCount", len(objectIDs)))
+
+	scheduledCount := 0
 	for _, oid := range objectIDs {
 		if err := s3helper.ScheduleS3Delete(ctx, mdb, sp.OrganizationID, sp.Bucket, oid); err != nil {
-			ll.Error("scheduleS3Delete", slog.String("error", err.Error()))
+			ll.Warn("Failed to schedule deletion for old segment file",
+				slog.Any("error", err),
+				slog.String("objectID", oid))
+		} else {
+			scheduledCount++
 		}
 	}
-	ll.Info("Scheduled old segments for deletion", slog.Int("count", len(objectIDs)))
+
+	ll.Info("Atomic operation completed successfully",
+		slog.Int("scheduledDeletions", scheduledCount),
+		slog.Int("totalFiles", len(objectIDs)))
+
 	return nil
 }

--- a/cmd/rollup_metrics.go
+++ b/cmd/rollup_metrics.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cardinalhq/lakerunner/internal/awsclient"
 	"github.com/cardinalhq/lakerunner/internal/awsclient/s3helper"
 	"github.com/cardinalhq/lakerunner/internal/helpers"
+	"github.com/cardinalhq/lakerunner/internal/idgen"
 	"github.com/cardinalhq/lakerunner/internal/storageprofile"
 	"github.com/cardinalhq/lakerunner/internal/tidprocessing"
 	"github.com/cardinalhq/lakerunner/lockmgr"
@@ -285,7 +286,7 @@ func rollupInterval(
 	// Process each tid_partition atomically
 	for tidPartition, result := range mergeResult {
 		// Generate operation ID for tracking this atomic operation
-		opID := fmt.Sprintf("rollup_op_%d_%d_%s", time.Now().Unix(), tidPartition, generateShortID())
+		opID := fmt.Sprintf("rollup_op_%d_%d_%s", time.Now().Unix(), tidPartition, idgen.GenerateShortBase32ID())
 		tidLogger := ll.With(slog.String("operationID", opID), slog.Int("tidPartition", int(tidPartition)))
 
 		tidLogger.Info("Starting atomic metric rollup operation",

--- a/go.mod
+++ b/go.mod
@@ -269,7 +269,7 @@ require (
 	github.com/go-toolsmith/astp v1.1.0 // indirect
 	github.com/go-toolsmith/strparse v1.1.0 // indirect
 	github.com/go-toolsmith/typep v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -583,8 +583,8 @@ github.com/go-toolsmith/strparse v1.1.0 h1:GAioeZUK9TGxnLS+qfdqNbA4z0SSm5zVNtCQi
 github.com/go-toolsmith/strparse v1.1.0/go.mod h1:7ksGy58fsaQkGQlY8WVoBFNyEPMGuJin1rfoPS4lBSQ=
 github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUNHus=
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUWY=
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=

--- a/internal/idgen/short.go
+++ b/internal/idgen/short.go
@@ -12,14 +12,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-package cmd
+package idgen
 
 import (
-	"github.com/cardinalhq/lakerunner/internal/idgen"
+	crand "crypto/rand"
+	"encoding/base32"
+	"strings"
 )
 
-// generateOperationID creates a unique operation ID for tracking atomic operations
-// Format: randomBase32
-func generateOperationID(index int) string {
-	return idgen.GenerateShortBase32ID()
+// GenerateShortBase32ID creates a short random base32 ID for operation tracking.
+// it is 8 characters long, and should not be used for security-sensitive operations.
+func GenerateShortBase32ID() string {
+	b := make([]byte, 5) // 5 bytes = 8 base32 chars
+	_, _ = crand.Read(b) // errors from rand.Read are rare and not critical for operation IDs
+	return strings.ToLower(base32.StdEncoding.EncodeToString(b))
 }

--- a/internal/idgen/short_test.go
+++ b/internal/idgen/short_test.go
@@ -12,14 +12,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-package cmd
+package idgen
 
 import (
-	"github.com/cardinalhq/lakerunner/internal/idgen"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// generateOperationID creates a unique operation ID for tracking atomic operations
-// Format: randomBase32
-func generateOperationID(index int) string {
-	return idgen.GenerateShortBase32ID()
+func TestGenerateShortBase32ID(t *testing.T) {
+	// Test that it returns a string
+	id := GenerateShortBase32ID()
+	assert.IsType(t, "", id, "GenerateShortBase32ID should return a string")
+	assert.NotEmpty(t, id, "GenerateShortBase32ID should return a non-empty string")
+
+	// Test that multiple calls return different IDs
+	id2 := GenerateShortBase32ID()
+	assert.NotEqual(t, id, id2, "GenerateShortBase32ID should return different values on subsequent calls")
 }

--- a/internal/metriccompaction/compaction.go
+++ b/internal/metriccompaction/compaction.go
@@ -16,9 +16,12 @@ package metriccompaction
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base32"
 	"fmt"
 	"log/slog"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/cardinalhq/lakerunner/internal/awsclient"
@@ -38,6 +41,13 @@ const (
 	WorkResultSuccess WorkResult = iota
 	WorkResultTryAgainLater
 )
+
+// generateShortID creates a short random base32 ID for operation tracking
+func generateShortID() string {
+	b := make([]byte, 5) // 5 bytes = 8 base32 chars
+	_, _ = rand.Read(b)  // errors from rand.Read are rare and not critical for operation IDs
+	return strings.TrimRight(base32.StdEncoding.EncodeToString(b), "=")
+}
 
 func ProcessItem(
 	ctx context.Context,
@@ -351,29 +361,85 @@ func compactInterval(
 	}
 
 	dateint, hour := helpers.MSToDateintHour(startTs)
+
+	// Process each tid_partition atomically
 	for tidPartition, result := range mergeResult {
+		// Generate operation ID for tracking this atomic operation
+		opID := fmt.Sprintf("metric_op_%d_%d_%s", time.Now().Unix(), tidPartition, generateShortID())
+		tidLogger := ll.With(slog.String("operationID", opID), slog.Int("tidPartition", tidPartition))
+
+		tidLogger.Info("Starting atomic metric compaction operation",
+			slog.Int64("recordCount", result.RecordCount),
+			slog.Int64("fileSize", result.FileSize))
+
 		segmentID := s3helper.GenerateID()
 		newObjectID := helpers.MakeDBObjectID(inf.OrganizationID(), profile.CollectorName, dateint, hour, segmentID, "metrics")
-		ll.Info("Uploading to S3", slog.String("objectID", newObjectID), slog.String("bucket", profile.Bucket))
+
+		tidLogger.Info("Uploading compacted metric file to S3 - point of no return approaching",
+			slog.String("newObjectID", newObjectID),
+			slog.String("bucket", profile.Bucket),
+			slog.Int64("newSegmentID", segmentID))
+
 		err = s3helper.UploadS3Object(ctx, s3client, profile.Bucket, newObjectID, result.FileName)
 		if err != nil {
-			ll.Error("Failed to upload new S3 object", slog.String("objectID", newObjectID), slog.Any("error", err))
+			tidLogger.Error("Atomic operation failed during S3 upload - no changes made",
+				slog.Any("error", err),
+				slog.String("objectID", newObjectID))
 			return fmt.Errorf("uploading new S3 object: %w", err)
 		}
-		params.NewRecords = append(params.NewRecords, lrdb.ReplaceMetricSegsNew{
-			TidPartition: int16(tidPartition),
-			SegmentID:    segmentID,
-			StartTs:      startTs,
-			EndTs:        endTs,
-			RecordCount:  result.RecordCount,
-			FileSize:     result.FileSize,
-			TidCount:     result.TidCount,
-		})
-	}
 
-	if err := mdb.ReplaceMetricSegs(ctx, params); err != nil {
-		ll.Error("Failed to replace metric segments", slog.Any("error", err))
-		return fmt.Errorf("replacing metric segments: %w", err)
+		tidLogger.Debug("S3 upload successful, updating database index - CRITICAL SECTION",
+			slog.String("uploadedObject", newObjectID))
+
+		// Create params for this single tid_partition
+		singleParams := lrdb.ReplaceMetricSegsParams{
+			OrganizationID: params.OrganizationID,
+			Dateint:        params.Dateint,
+			FrequencyMs:    params.FrequencyMs,
+			InstanceNum:    params.InstanceNum,
+			IngestDateint:  params.IngestDateint,
+			Published:      params.Published,
+			Rolledup:       params.Rolledup,
+			CreatedBy:      params.CreatedBy,
+			OldRecords:     params.OldRecords, // Contains all old records, but DB will filter by tid_partition
+			NewRecords: []lrdb.ReplaceMetricSegsNew{
+				{
+					TidPartition: int16(tidPartition),
+					SegmentID:    segmentID,
+					StartTs:      startTs,
+					EndTs:        endTs,
+					RecordCount:  result.RecordCount,
+					FileSize:     result.FileSize,
+					TidCount:     result.TidCount,
+				},
+			},
+		}
+
+		if err := mdb.ReplaceMetricSegs(ctx, singleParams); err != nil {
+			tidLogger.Error("CRITICAL: Database update failed after S3 upload - file orphaned in S3",
+				slog.Any("error", err),
+				slog.String("orphanedObject", newObjectID),
+				slog.Int64("orphanedSegmentID", segmentID),
+				slog.String("bucket", profile.Bucket))
+
+			// Best effort cleanup - try to delete the uploaded file
+			tidLogger.Debug("Attempting to cleanup orphaned S3 object")
+			if cleanupErr := s3helper.DeleteS3Object(ctx, s3client, profile.Bucket, newObjectID); cleanupErr != nil {
+				tidLogger.Error("Failed to cleanup orphaned S3 object - manual cleanup required",
+					slog.Any("error", cleanupErr),
+					slog.String("objectID", newObjectID),
+					slog.String("bucket", profile.Bucket))
+			} else {
+				tidLogger.Info("Successfully cleaned up orphaned S3 object")
+			}
+			return fmt.Errorf("replacing metric segments: %w", err)
+		}
+
+		tidLogger.Info("ATOMIC OPERATION COMMITTED SUCCESSFULLY - database updated, segments swapped",
+			slog.Int64("newSegmentID", segmentID),
+			slog.Int64("newRecordCount", result.RecordCount),
+			slog.Int64("newFileSize", result.FileSize),
+			slog.String("newObjectID", newObjectID))
 	}
 
 	for _, row := range rows {


### PR DESCRIPTION
Compaction tasks can take a while to run, and end up making multiple internal blocks that can be handled independently, and are atomic within their block of (download, upload, update index).  This is now the work unit that can be interrupted, preventing a large compact with many files from ignoring k8s request to exit and ultimately being force quit somewhere in the middle of an operation.