### PR TITLE
Restrict migration check to main and improve script portability

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -2,6 +2,7 @@ name: Migration Integrity Check
 
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'lrdb/migrations/**'
       - 'configdb/migrations/**'

--- a/scripts/check-migration-integrity.sh
+++ b/scripts/check-migration-integrity.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2025 CardinalHQ, Inc
 #
@@ -69,8 +69,8 @@ normalize_sql() {
     # Convert to lowercase for case-insensitive comparison
     echo "$content" | \
         sed 's/--.*$//' | \
-        sed '/^\s*$/d' | \
-        sed 's/[[:space:]]\+/ /g' | \
+        sed '/^[[:space:]]*$/d' | \
+        sed -E 's/[[:space:]]+/ /g' | \
         sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | \
         tr '[:upper:]' '[:lower:]'
 }


### PR DESCRIPTION
## Summary
- run migration integrity workflow only for PRs targeting `main`
- make migration integrity script more portable across macOS/Linux

## Testing
- `./scripts/check-migration-integrity.sh main`
- `make test license-check` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a83b16288321b83e0643ef1fa560