### PR TITLE
migration check + healthcheck

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,23 @@ Rules:
 
 ---
 
+## Health Checks
+
+Worker services provide HTTP health check endpoints for Kubernetes monitoring:
+
+- **`/healthz`** – Main health check endpoint (200 when healthy, 503 when not)
+- **`/readyz`** – Readiness probe (200 when ready to accept traffic)
+- **`/livez`** – Liveness probe (200 unless service is completely broken)
+
+Services with health checks:
+- **query-api** – Query API server
+- **query-worker** – Query worker service  
+- **sweeper** – Background cleanup service
+
+Health check responses include JSON with status, timestamp, and service name.
+
+---
+
 ## Storage Profiles & Configuration
 
 Configuration is YAML-based:
@@ -158,6 +175,11 @@ Configuration is YAML-based:
 - `MIGRATION_CHECK_TIMEOUT` – maximum time to wait for migrations to complete (default: 60s)
 - `MIGRATION_CHECK_RETRY_INTERVAL` – interval between migration version checks (default: 5s)
 - `MIGRATION_CHECK_ALLOW_DIRTY` – allow connections to databases with dirty migration state (default: false)
+
+**Health Check Environment Variables:**
+
+- `HEALTH_CHECK_PORT` – port for HTTP health check server (default: 8090)
+- `HEALTH_CHECK_SERVICE_NAME` – service name in health check responses (default: command-specific)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,14 @@ Configuration is YAML-based:
 - `GOGC` – GC tuning (default 50%)
 - Inside the container, memory and cpu limits for Go will match the constraints of the container.
 
+**Migration Version Check Environment Variables:**
+
+- `LRDB_MIGRATION_CHECK_ENABLED` – enable/disable migration version check for lrdb (default: true)
+- `CONFIGDB_MIGRATION_CHECK_ENABLED` – enable/disable migration version check for configdb (default: true)
+- `MIGRATION_CHECK_TIMEOUT` – maximum time to wait for migrations to complete (default: 60s)
+- `MIGRATION_CHECK_RETRY_INTERVAL` – interval between migration version checks (default: 5s)
+- `MIGRATION_CHECK_ALLOW_DIRTY` – allow connections to databases with dirty migration state (default: false)
+
 ---
 
 ## Docker & Release

--- a/cmd/dbopen/dbopen_configdb.go
+++ b/cmd/dbopen/dbopen_configdb.go
@@ -22,14 +22,34 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/cardinalhq/lakerunner/configdb"
+	configdbmigrations "github.com/cardinalhq/lakerunner/configdb/migrations"
 )
 
-func ConnectToConfigDB(ctx context.Context) (*pgxpool.Pool, error) {
+func ConnectToConfigDB(ctx context.Context, opts ...Options) (*pgxpool.Pool, error) {
 	connectionString, err := getDatabaseURLFromEnv("CONFIGDB")
 	if err != nil {
 		return nil, errors.Join(ErrDatabaseNotConfigured, fmt.Errorf("failed to get CONFIGDB connection string: %w", err))
 	}
-	return configdb.NewConnectionPool(ctx, connectionString)
+
+	pool, err := configdb.NewConnectionPool(ctx, connectionString)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if migration check should be skipped
+	skipMigrationCheck := false
+	if len(opts) > 0 {
+		skipMigrationCheck = opts[0].SkipMigrationCheck
+	}
+
+	if !skipMigrationCheck {
+		if err := configdbmigrations.CheckExpectedVersion(ctx, pool); err != nil {
+			pool.Close()
+			return nil, fmt.Errorf("CONFIGDB migration version check failed: %w", err)
+		}
+	}
+
+	return pool, nil
 }
 
 func ConfigDBStore(ctx context.Context) (configdb.QuerierFull, error) {

--- a/cmd/dbopen/migration_check.go
+++ b/cmd/dbopen/migration_check.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package dbopen
+
+// Options configures database connection behavior
+type Options struct {
+	SkipMigrationCheck bool
+}

--- a/cmd/dbopen/migration_check_test.go
+++ b/cmd/dbopen/migration_check_test.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package dbopen
+
+import (
+	"testing"
+)
+
+func TestOptions(t *testing.T) {
+	// Test default options
+	opts := Options{}
+	if opts.SkipMigrationCheck {
+		t.Error("Expected SkipMigrationCheck to default to false")
+	}
+
+	// Test configured options
+	opts = Options{SkipMigrationCheck: true}
+	if !opts.SkipMigrationCheck {
+		t.Error("Expected SkipMigrationCheck to be true")
+	}
+}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -103,7 +103,7 @@ func migrate(_ *cobra.Command, _ []string) error {
 func migratelrdb() error {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Minute))
 	defer cancel()
-	pool, err := dbopen.ConnectTolrdb(ctx)
+	pool, err := dbopen.ConnectTolrdb(ctx, dbopen.Options{SkipMigrationCheck: true})
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func migrateconfigdb() error {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Minute))
 	defer cancel()
 
-	pool, err := dbopen.ConnectToConfigDB(ctx)
+	pool, err := dbopen.ConnectToConfigDB(ctx, dbopen.Options{SkipMigrationCheck: true})
 	if err != nil {
 		if errors.Is(err, dbopen.ErrDatabaseNotConfigured) {
 			slog.Info("ConfigDB not configured, skipping migration")
@@ -128,7 +128,7 @@ func migrateconfigdb() error {
 func initializeIfNeededFunc() error {
 	ctx := context.Background()
 
-	configDBPool, err := dbopen.ConnectToConfigDB(ctx)
+	configDBPool, err := dbopen.ConnectToConfigDB(ctx, dbopen.Options{SkipMigrationCheck: true})
 	if err != nil {
 		if errors.Is(err, dbopen.ErrDatabaseNotConfigured) {
 			slog.Info("ConfigDB not configured, skipping initialization")

--- a/configdb/migrations/version.go
+++ b/configdb/migrations/version.go
@@ -1,0 +1,239 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/pgx"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+// GetMigrationFiles returns the embedded migration files for version checking
+func GetMigrationFiles() embed.FS {
+	return migrationFiles
+}
+
+// CheckExpectedVersion verifies that the configdb database is at the expected migration version
+func CheckExpectedVersion(ctx context.Context, pool *pgxpool.Pool) error {
+	// Get configuration from environment
+	config := getMigrationCheckConfig()
+	if !config.Enabled {
+		slog.Debug("Migration version checking disabled for configdb")
+		return nil
+	}
+
+	return checkMigrationVersion(ctx, pool, migrationFiles, "gomigrate_lrconfigdb", "configdb", config)
+}
+
+// migrationCheckConfig holds configuration for migration version checking
+type migrationCheckConfig struct {
+	Enabled       bool
+	Timeout       time.Duration
+	RetryInterval time.Duration
+	AllowDirty    bool
+}
+
+// getMigrationCheckConfig returns migration check configuration from environment variables
+func getMigrationCheckConfig() migrationCheckConfig {
+	enabled := true
+	if val := os.Getenv("CONFIGDB_MIGRATION_CHECK_ENABLED"); val != "" {
+		enabled = strings.ToLower(val) == "true"
+	}
+
+	timeout := 60 * time.Second
+	if val := os.Getenv("MIGRATION_CHECK_TIMEOUT"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			timeout = d
+		}
+	}
+
+	retryInterval := 5 * time.Second
+	if val := os.Getenv("MIGRATION_CHECK_RETRY_INTERVAL"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			retryInterval = d
+		}
+	}
+
+	allowDirty := false
+	if val := os.Getenv("MIGRATION_CHECK_ALLOW_DIRTY"); val != "" {
+		allowDirty = strings.ToLower(val) == "true"
+	}
+
+	return migrationCheckConfig{
+		Enabled:       enabled,
+		Timeout:       timeout,
+		RetryInterval: retryInterval,
+		AllowDirty:    allowDirty,
+	}
+}
+
+// extractLatestMigrationVersion extracts the highest migration version from embedded migration files
+func extractLatestMigrationVersion(migrationFiles embed.FS) (uint, error) {
+	entries, err := migrationFiles.ReadDir(".")
+	if err != nil {
+		return 0, fmt.Errorf("failed to read migration directory: %w", err)
+	}
+
+	var maxVersion uint
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+
+		// Extract version from filename like "1751057788_initial.up.sql"
+		parts := strings.SplitN(name, "_", 2)
+		if len(parts) < 1 {
+			continue
+		}
+
+		version, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if uint(version) > maxVersion {
+			maxVersion = uint(version)
+		}
+	}
+
+	if maxVersion == 0 {
+		return 0, fmt.Errorf("no valid migration files found")
+	}
+
+	return maxVersion, nil
+}
+
+// checkMigrationVersion verifies that the database is at the expected migration version
+func checkMigrationVersion(ctx context.Context, pool *pgxpool.Pool, migrationFiles embed.FS, migrationTable string, dbName string, config migrationCheckConfig) error {
+	expectedVersion, err := extractLatestMigrationVersion(migrationFiles)
+	if err != nil {
+		return fmt.Errorf("failed to extract expected migration version for %s: %w", dbName, err)
+	}
+
+	slog.Info("Checking migration version",
+		slog.String("database", dbName),
+		slog.Uint64("expected_version", uint64(expectedVersion)),
+		slog.Duration("timeout", config.Timeout))
+
+	deadline := time.Now().Add(config.Timeout)
+	ticker := time.NewTicker(config.RetryInterval)
+	defer ticker.Stop()
+
+	for {
+		currentVersion, dirty, err := getCurrentMigrationVersion(ctx, pool, migrationFiles, migrationTable)
+		if err != nil {
+			return fmt.Errorf("failed to get current migration version for %s: %w", dbName, err)
+		}
+
+		if dirty && !config.AllowDirty {
+			return fmt.Errorf("database %s migration is in dirty state, please fix before proceeding", dbName)
+		}
+
+		if dirty {
+			slog.Warn("Database migration is dirty but allowed to continue", slog.String("database", dbName))
+		}
+
+		slog.Debug("Migration version check",
+			slog.String("database", dbName),
+			slog.Uint64("current_version", uint64(currentVersion)),
+			slog.Uint64("expected_version", uint64(expectedVersion)),
+			slog.Bool("dirty", dirty))
+
+		if currentVersion == expectedVersion {
+			slog.Info("Migration version check passed",
+				slog.String("database", dbName),
+				slog.Uint64("version", uint64(currentVersion)))
+			return nil
+		}
+
+		if currentVersion > expectedVersion {
+			return fmt.Errorf("database %s version %d is newer than expected version %d - you may need to update the application",
+				dbName, currentVersion, expectedVersion)
+		}
+
+		// currentVersion < expectedVersion
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for %s migration to complete: current version %d, expected %d",
+				dbName, currentVersion, expectedVersion)
+		}
+
+		slog.Info("Waiting for migrations to complete",
+			slog.String("database", dbName),
+			slog.Uint64("current_version", uint64(currentVersion)),
+			slog.Uint64("expected_version", uint64(expectedVersion)),
+			slog.Duration("remaining_timeout", time.Until(deadline)))
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for %s migrations", dbName)
+		case <-ticker.C:
+			// Continue checking
+		}
+	}
+}
+
+// getCurrentMigrationVersion gets the current migration version from the database
+func getCurrentMigrationVersion(ctx context.Context, pool *pgxpool.Pool, migrationFiles embed.FS, migrationTable string) (uint, bool, error) {
+	sourceDriver, err := iofs.New(migrationFiles, ".")
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create iofs driver: %w", err)
+	}
+
+	sqlDB := stdlib.OpenDBFromPool(pool)
+	defer func() {
+		_ = sqlDB.Close()
+	}()
+
+	dbDriver, err := pgx.WithInstance(sqlDB, &pgx.Config{
+		MigrationsTable: migrationTable,
+	})
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create pgx driver: %w", err)
+	}
+	defer func() {
+		_ = dbDriver.Close()
+	}()
+
+	m, err := migrate.NewWithInstance("iofs", sourceDriver, "postgres", dbDriver)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create migrate instance: %w", err)
+	}
+
+	version, dirty, err := m.Version()
+	if err != nil {
+		if err == migrate.ErrNilVersion {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("failed to get current version: %w", err)
+	}
+
+	return version, dirty, nil
+}

--- a/configdb/migrations/version_test.go
+++ b/configdb/migrations/version_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestExtractLatestMigrationVersion(t *testing.T) {
+	got, err := extractLatestMigrationVersion(migrationFiles)
+	if err != nil {
+		t.Errorf("extractLatestMigrationVersion() error = %v", err)
+		return
+	}
+	// The exact version depends on the current migrations, but it should be > 0
+	if got == 0 {
+		t.Error("extractLatestMigrationVersion() returned 0, expected a valid version")
+	}
+	t.Logf("Latest configdb migration version: %d", got)
+}
+
+func TestGetMigrationCheckConfig(t *testing.T) {
+	// Save original environment
+	originalVars := make(map[string]string)
+	envVars := []string{
+		"CONFIGDB_MIGRATION_CHECK_ENABLED",
+		"MIGRATION_CHECK_TIMEOUT",
+		"MIGRATION_CHECK_RETRY_INTERVAL",
+		"MIGRATION_CHECK_ALLOW_DIRTY",
+	}
+
+	for _, key := range envVars {
+		if val := os.Getenv(key); val != "" {
+			originalVars[key] = val
+		}
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for _, key := range envVars {
+			os.Unsetenv(key)
+		}
+		for key, val := range originalVars {
+			os.Setenv(key, val)
+		}
+	}()
+
+	// Test defaults
+	config := getMigrationCheckConfig()
+	if !config.Enabled {
+		t.Error("Expected Enabled to default to true")
+	}
+	if config.Timeout != 60*time.Second {
+		t.Errorf("Expected Timeout to default to 60s, got %v", config.Timeout)
+	}
+	if config.RetryInterval != 5*time.Second {
+		t.Errorf("Expected RetryInterval to default to 5s, got %v", config.RetryInterval)
+	}
+	if config.AllowDirty {
+		t.Error("Expected AllowDirty to default to false")
+	}
+
+	// Test custom values
+	os.Setenv("CONFIGDB_MIGRATION_CHECK_ENABLED", "false")
+	os.Setenv("MIGRATION_CHECK_TIMEOUT", "30s")
+	os.Setenv("MIGRATION_CHECK_RETRY_INTERVAL", "2s")
+	os.Setenv("MIGRATION_CHECK_ALLOW_DIRTY", "true")
+
+	config = getMigrationCheckConfig()
+	if config.Enabled {
+		t.Error("Expected Enabled to be false")
+	}
+	if config.Timeout != 30*time.Second {
+		t.Errorf("Expected Timeout to be 30s, got %v", config.Timeout)
+	}
+	if config.RetryInterval != 2*time.Second {
+		t.Errorf("Expected RetryInterval to be 2s, got %v", config.RetryInterval)
+	}
+	if !config.AllowDirty {
+		t.Error("Expected AllowDirty to be true")
+	}
+}

--- a/internal/healthcheck/server.go
+++ b/internal/healthcheck/server.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package healthcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+type Status int32
+
+const (
+	StatusStarting Status = iota
+	StatusHealthy
+	StatusUnhealthy
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusStarting:
+		return "starting"
+	case StatusHealthy:
+		return "healthy"
+	case StatusUnhealthy:
+		return "unhealthy"
+	default:
+		return "unknown"
+	}
+}
+
+type Response struct {
+	Healthy bool `json:"healthy"`
+}
+
+type Server struct {
+	port   int
+	status atomic.Int32
+	server *http.Server
+}
+
+type Config struct {
+	Port int
+}
+
+func GetConfigFromEnv() Config {
+	port := 8090
+	if portStr := os.Getenv("HEALTH_CHECK_PORT"); portStr != "" {
+		if p, err := strconv.Atoi(portStr); err == nil && p > 0 && p < 65536 {
+			port = p
+		}
+	}
+
+	return Config{
+		Port: port,
+	}
+}
+
+func NewServer(config Config) *Server {
+	if config.Port == 0 {
+		config.Port = 8090
+	}
+
+	return &Server{
+		port: config.Port,
+	}
+}
+
+func (s *Server) SetStatus(status Status) {
+	s.status.Store(int32(status))
+	slog.Debug("Health check status updated", slog.String("status", status.String()))
+}
+
+func (s *Server) GetStatus() Status {
+	return Status(s.status.Load())
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.healthzHandler)
+	mux.HandleFunc("/readyz", s.readyzHandler)
+	mux.HandleFunc("/livez", s.livezHandler)
+
+	s.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", s.port),
+		Handler: mux,
+	}
+
+	s.SetStatus(StatusStarting)
+	slog.Info("Starting health check server", slog.Int("port", s.port))
+
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("Health check server error", slog.Any("error", err))
+		}
+	}()
+
+	<-ctx.Done()
+	return s.Stop()
+}
+
+func (s *Server) Stop() error {
+	if s.server == nil {
+		return nil
+	}
+
+	slog.Info("Stopping health check server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	return s.server.Shutdown(ctx)
+}
+
+func (s *Server) healthzHandler(w http.ResponseWriter, r *http.Request) {
+	status := s.GetStatus()
+	isHealthy := status == StatusHealthy
+	response := Response{Healthy: isHealthy}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if isHealthy {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		slog.Error("Failed to encode health check response", slog.Any("error", err))
+	}
+}
+
+func (s *Server) readyzHandler(w http.ResponseWriter, r *http.Request) {
+	status := s.GetStatus()
+	isHealthy := status == StatusHealthy
+	response := Response{Healthy: isHealthy}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if isHealthy {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		slog.Error("Failed to encode health check response", slog.Any("error", err))
+	}
+}
+
+func (s *Server) livezHandler(w http.ResponseWriter, r *http.Request) {
+	status := s.GetStatus()
+	isAlive := status != StatusUnhealthy
+	response := Response{Healthy: isAlive}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if isAlive {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		slog.Error("Failed to encode health check response", slog.Any("error", err))
+	}
+}

--- a/internal/healthcheck/server_test.go
+++ b/internal/healthcheck/server_test.go
@@ -1,0 +1,218 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package healthcheck
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestStatus_String(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   string
+	}{
+		{StatusStarting, "starting"},
+		{StatusHealthy, "healthy"},
+		{StatusUnhealthy, "unhealthy"},
+		{Status(999), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("Status.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConfigFromEnv(t *testing.T) {
+	// Save original environment
+	originalPort := os.Getenv("HEALTH_CHECK_PORT")
+	os.Unsetenv("HEALTH_CHECK_PORT")
+	defer func() {
+		os.Unsetenv("HEALTH_CHECK_PORT")
+		if originalPort != "" {
+			os.Setenv("HEALTH_CHECK_PORT", originalPort)
+		}
+	}()
+
+	// Test defaults
+	config := GetConfigFromEnv()
+	if config.Port != 8090 {
+		t.Errorf("Expected Port to default to 8090, got %d", config.Port)
+	}
+
+	// Test custom values
+	os.Setenv("HEALTH_CHECK_PORT", "9090")
+
+	config = GetConfigFromEnv()
+	if config.Port != 9090 {
+		t.Errorf("Expected Port to be 9090, got %d", config.Port)
+	}
+
+	// Test invalid port
+	os.Setenv("HEALTH_CHECK_PORT", "invalid")
+	config = GetConfigFromEnv()
+	if config.Port != 8090 {
+		t.Errorf("Expected Port to fallback to 8090 for invalid value, got %d", config.Port)
+	}
+}
+
+func TestNewServer(t *testing.T) {
+	// Test with empty config
+	server := NewServer(Config{})
+	if server.port != 8090 {
+		t.Errorf("Expected default port 8090, got %d", server.port)
+	}
+
+	// Test with custom config
+	config := Config{
+		Port: 9090,
+	}
+	server = NewServer(config)
+	if server.port != 9090 {
+		t.Errorf("Expected port 9090, got %d", server.port)
+	}
+}
+
+func TestServer_SetGetStatus(t *testing.T) {
+	server := NewServer(Config{})
+
+	// Test initial status
+	status := server.GetStatus()
+	if status != StatusStarting {
+		t.Errorf("Expected initial status to be StatusStarting, got %v", status)
+	}
+
+	// Test setting status
+	server.SetStatus(StatusHealthy)
+	status = server.GetStatus()
+	if status != StatusHealthy {
+		t.Errorf("Expected status to be StatusHealthy, got %v", status)
+	}
+
+	server.SetStatus(StatusUnhealthy)
+	status = server.GetStatus()
+	if status != StatusUnhealthy {
+		t.Errorf("Expected status to be StatusUnhealthy, got %v", status)
+	}
+}
+
+func TestHealthEndpoints(t *testing.T) {
+	config := Config{
+		Port: 8090,
+	}
+	server := NewServer(config)
+
+	// Start server in background
+	ctx := t.Context()
+
+	go func() {
+		_ = server.Start(ctx)
+	}()
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// We can't easily test the actual HTTP endpoints without knowing the port
+	// So we'll test the handler methods directly
+
+	tests := []struct {
+		name            string
+		status          Status
+		endpoint        string
+		expectedStatus  int
+		expectedHealthy bool
+	}{
+		{"healthz starting", StatusStarting, "/healthz", http.StatusServiceUnavailable, false},
+		{"healthz healthy", StatusHealthy, "/healthz", http.StatusOK, true},
+		{"healthz unhealthy", StatusUnhealthy, "/healthz", http.StatusServiceUnavailable, false},
+		{"readyz starting", StatusStarting, "/readyz", http.StatusServiceUnavailable, false},
+		{"readyz healthy", StatusHealthy, "/readyz", http.StatusOK, true},
+		{"readyz unhealthy", StatusUnhealthy, "/readyz", http.StatusServiceUnavailable, false},
+		{"livez starting", StatusStarting, "/livez", http.StatusOK, true},
+		{"livez healthy", StatusHealthy, "/livez", http.StatusOK, true},
+		{"livez unhealthy", StatusUnhealthy, "/livez", http.StatusServiceUnavailable, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server.SetStatus(tt.status)
+
+			// Create a mock request
+			req, err := http.NewRequest("GET", tt.endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create a response recorder
+			rr := &mockResponseWriter{
+				header: make(http.Header),
+				body:   make([]byte, 0),
+			}
+
+			// Call the appropriate handler
+			switch tt.endpoint {
+			case "/healthz":
+				server.healthzHandler(rr, req)
+			case "/readyz":
+				server.readyzHandler(rr, req)
+			case "/livez":
+				server.livezHandler(rr, req)
+			}
+
+			// Check status code
+			if rr.statusCode != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, rr.statusCode)
+			}
+
+			// Check that response is valid JSON
+			var response Response
+			if err := json.Unmarshal(rr.body, &response); err != nil {
+				t.Errorf("Invalid JSON response: %v", err)
+			}
+
+			// Check response fields
+			if response.Healthy != tt.expectedHealthy {
+				t.Errorf("Expected healthy %v, got %v", tt.expectedHealthy, response.Healthy)
+			}
+		})
+	}
+}
+
+// mockResponseWriter implements http.ResponseWriter for testing
+type mockResponseWriter struct {
+	header     http.Header
+	body       []byte
+	statusCode int
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	return m.header
+}
+
+func (m *mockResponseWriter) Write(data []byte) (int, error) {
+	m.body = append(m.body, data...)
+	return len(data), nil
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+	m.statusCode = statusCode
+}

--- a/lrdb/migrations/version.go
+++ b/lrdb/migrations/version.go
@@ -1,0 +1,239 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/pgx"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+)
+
+// GetMigrationFiles returns the embedded migration files for version checking
+func GetMigrationFiles() embed.FS {
+	return migrationFiles
+}
+
+// CheckExpectedVersion verifies that the lrdb database is at the expected migration version
+func CheckExpectedVersion(ctx context.Context, pool *pgxpool.Pool) error {
+	// Get configuration from environment
+	config := getMigrationCheckConfig()
+	if !config.Enabled {
+		slog.Debug("Migration version checking disabled for lrdb")
+		return nil
+	}
+
+	return checkMigrationVersion(ctx, pool, migrationFiles, "gomigrate_lrdb", "lrdb", config)
+}
+
+// migrationCheckConfig holds configuration for migration version checking
+type migrationCheckConfig struct {
+	Enabled       bool
+	Timeout       time.Duration
+	RetryInterval time.Duration
+	AllowDirty    bool
+}
+
+// getMigrationCheckConfig returns migration check configuration from environment variables
+func getMigrationCheckConfig() migrationCheckConfig {
+	enabled := true
+	if val := os.Getenv("LRDB_MIGRATION_CHECK_ENABLED"); val != "" {
+		enabled = strings.ToLower(val) == "true"
+	}
+
+	timeout := 60 * time.Second
+	if val := os.Getenv("MIGRATION_CHECK_TIMEOUT"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			timeout = d
+		}
+	}
+
+	retryInterval := 5 * time.Second
+	if val := os.Getenv("MIGRATION_CHECK_RETRY_INTERVAL"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			retryInterval = d
+		}
+	}
+
+	allowDirty := false
+	if val := os.Getenv("MIGRATION_CHECK_ALLOW_DIRTY"); val != "" {
+		allowDirty = strings.ToLower(val) == "true"
+	}
+
+	return migrationCheckConfig{
+		Enabled:       enabled,
+		Timeout:       timeout,
+		RetryInterval: retryInterval,
+		AllowDirty:    allowDirty,
+	}
+}
+
+// extractLatestMigrationVersion extracts the highest migration version from embedded migration files
+func extractLatestMigrationVersion(migrationFiles embed.FS) (uint, error) {
+	entries, err := migrationFiles.ReadDir(".")
+	if err != nil {
+		return 0, fmt.Errorf("failed to read migration directory: %w", err)
+	}
+
+	var maxVersion uint
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+
+		// Extract version from filename like "1751057788_initial.up.sql"
+		parts := strings.SplitN(name, "_", 2)
+		if len(parts) < 1 {
+			continue
+		}
+
+		version, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if uint(version) > maxVersion {
+			maxVersion = uint(version)
+		}
+	}
+
+	if maxVersion == 0 {
+		return 0, fmt.Errorf("no valid migration files found")
+	}
+
+	return maxVersion, nil
+}
+
+// checkMigrationVersion verifies that the database is at the expected migration version
+func checkMigrationVersion(ctx context.Context, pool *pgxpool.Pool, migrationFiles embed.FS, migrationTable string, dbName string, config migrationCheckConfig) error {
+	expectedVersion, err := extractLatestMigrationVersion(migrationFiles)
+	if err != nil {
+		return fmt.Errorf("failed to extract expected migration version for %s: %w", dbName, err)
+	}
+
+	slog.Info("Checking migration version",
+		slog.String("database", dbName),
+		slog.Uint64("expected_version", uint64(expectedVersion)),
+		slog.Duration("timeout", config.Timeout))
+
+	deadline := time.Now().Add(config.Timeout)
+	ticker := time.NewTicker(config.RetryInterval)
+	defer ticker.Stop()
+
+	for {
+		currentVersion, dirty, err := getCurrentMigrationVersion(ctx, pool, migrationFiles, migrationTable)
+		if err != nil {
+			return fmt.Errorf("failed to get current migration version for %s: %w", dbName, err)
+		}
+
+		if dirty && !config.AllowDirty {
+			return fmt.Errorf("database %s migration is in dirty state, please fix before proceeding", dbName)
+		}
+
+		if dirty {
+			slog.Warn("Database migration is dirty but allowed to continue", slog.String("database", dbName))
+		}
+
+		slog.Debug("Migration version check",
+			slog.String("database", dbName),
+			slog.Uint64("current_version", uint64(currentVersion)),
+			slog.Uint64("expected_version", uint64(expectedVersion)),
+			slog.Bool("dirty", dirty))
+
+		if currentVersion == expectedVersion {
+			slog.Info("Migration version check passed",
+				slog.String("database", dbName),
+				slog.Uint64("version", uint64(currentVersion)))
+			return nil
+		}
+
+		if currentVersion > expectedVersion {
+			return fmt.Errorf("database %s version %d is newer than expected version %d - you may need to update the application",
+				dbName, currentVersion, expectedVersion)
+		}
+
+		// currentVersion < expectedVersion
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for %s migration to complete: current version %d, expected %d",
+				dbName, currentVersion, expectedVersion)
+		}
+
+		slog.Info("Waiting for migrations to complete",
+			slog.String("database", dbName),
+			slog.Uint64("current_version", uint64(currentVersion)),
+			slog.Uint64("expected_version", uint64(expectedVersion)),
+			slog.Duration("remaining_timeout", time.Until(deadline)))
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for %s migrations", dbName)
+		case <-ticker.C:
+			// Continue checking
+		}
+	}
+}
+
+// getCurrentMigrationVersion gets the current migration version from the database
+func getCurrentMigrationVersion(ctx context.Context, pool *pgxpool.Pool, migrationFiles embed.FS, migrationTable string) (uint, bool, error) {
+	sourceDriver, err := iofs.New(migrationFiles, ".")
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create iofs driver: %w", err)
+	}
+
+	sqlDB := stdlib.OpenDBFromPool(pool)
+	defer func() {
+		_ = sqlDB.Close()
+	}()
+
+	dbDriver, err := pgx.WithInstance(sqlDB, &pgx.Config{
+		MigrationsTable: migrationTable,
+	})
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create pgx driver: %w", err)
+	}
+	defer func() {
+		_ = dbDriver.Close()
+	}()
+
+	m, err := migrate.NewWithInstance("iofs", sourceDriver, "postgres", dbDriver)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create migrate instance: %w", err)
+	}
+
+	version, dirty, err := m.Version()
+	if err != nil {
+		if err == migrate.ErrNilVersion {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("failed to get current version: %w", err)
+	}
+
+	return version, dirty, nil
+}

--- a/lrdb/migrations/version_test.go
+++ b/lrdb/migrations/version_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestExtractLatestMigrationVersion(t *testing.T) {
+	got, err := extractLatestMigrationVersion(migrationFiles)
+	if err != nil {
+		t.Errorf("extractLatestMigrationVersion() error = %v", err)
+		return
+	}
+	// The exact version depends on the current migrations, but it should be > 0
+	if got == 0 {
+		t.Error("extractLatestMigrationVersion() returned 0, expected a valid version")
+	}
+	t.Logf("Latest lrdb migration version: %d", got)
+}
+
+func TestGetMigrationCheckConfig(t *testing.T) {
+	// Save original environment
+	originalVars := make(map[string]string)
+	envVars := []string{
+		"LRDB_MIGRATION_CHECK_ENABLED",
+		"MIGRATION_CHECK_TIMEOUT",
+		"MIGRATION_CHECK_RETRY_INTERVAL",
+		"MIGRATION_CHECK_ALLOW_DIRTY",
+	}
+
+	for _, key := range envVars {
+		if val := os.Getenv(key); val != "" {
+			originalVars[key] = val
+		}
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for _, key := range envVars {
+			os.Unsetenv(key)
+		}
+		for key, val := range originalVars {
+			os.Setenv(key, val)
+		}
+	}()
+
+	// Test defaults
+	config := getMigrationCheckConfig()
+	if !config.Enabled {
+		t.Error("Expected Enabled to default to true")
+	}
+	if config.Timeout != 60*time.Second {
+		t.Errorf("Expected Timeout to default to 60s, got %v", config.Timeout)
+	}
+	if config.RetryInterval != 5*time.Second {
+		t.Errorf("Expected RetryInterval to default to 5s, got %v", config.RetryInterval)
+	}
+	if config.AllowDirty {
+		t.Error("Expected AllowDirty to default to false")
+	}
+
+	// Test custom values
+	os.Setenv("LRDB_MIGRATION_CHECK_ENABLED", "false")
+	os.Setenv("MIGRATION_CHECK_TIMEOUT", "30s")
+	os.Setenv("MIGRATION_CHECK_RETRY_INTERVAL", "2s")
+	os.Setenv("MIGRATION_CHECK_ALLOW_DIRTY", "true")
+
+	config = getMigrationCheckConfig()
+	if config.Enabled {
+		t.Error("Expected Enabled to be false")
+	}
+	if config.Timeout != 30*time.Second {
+		t.Errorf("Expected Timeout to be 30s, got %v", config.Timeout)
+	}
+	if config.RetryInterval != 2*time.Second {
+		t.Errorf("Expected RetryInterval to be 2s, got %v", config.RetryInterval)
+	}
+	if !config.AllowDirty {
+		t.Error("Expected AllowDirty to be true")
+	}
+}


### PR DESCRIPTION
Add a check at startup to prevent services from starting until migrations are applied, with a timeout.

Add a simple health check endpoint for k8s.