### PR TITLE
refactor: close JSONLines underlying reader

### DIFF
--- a/internal/filereader/doc.go
+++ b/internal/filereader/doc.go
@@ -44,7 +44,7 @@
 // All format readers return raw, untransformed data from files:
 //
 //   - ParquetReader: Generic Parquet files using parquet-go/parquet-go (requires io.ReaderAt)
-//   - JSONLinesReader: Streams JSON objects line-by-line from any io.Reader
+//   - JSONLinesReader: Streams JSON objects line-by-line from any io.ReadCloser
 //   - ProtoLogsReader: Raw OTEL log records from protobuf
 //   - ProtoMetricsReader: Raw OTEL metric data points from protobuf
 //   - ProtoTracesReader: Raw OTEL span data from protobuf
@@ -56,7 +56,6 @@
 //	if err != nil {
 //	    return err
 //	}
-//	defer gzReader.Close()
 //
 //	reader, err := NewJSONLinesReader(gzReader)
 //	if err != nil {


### PR DESCRIPTION
## Summary
- ensure JSONLinesReader owns an `io.ReadCloser` and closes it
- add helper closer for JSON.gz files in reader factory
- update docs and tests for new ownership semantics

## Testing
- `go test ./internal/filereader`
- `make test` *(failed: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68abe50d529483219b4a1c4fb350fee8