### PR TITLE
Introduce ArrowCookedReader using Apache Arrow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/pubsub v1.49.0
 	github.com/DataDog/sketches-go v1.4.7
 	github.com/KimMachineGun/automemlimit v0.7.4
+	github.com/apache/arrow-go/v18 v18.4.0
 	github.com/aws/aws-sdk-go-v2 v1.38.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.4
@@ -122,8 +123,8 @@ require (
 	github.com/anchore/quill v0.5.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/apache/arrow-go/v18 v18.4.0 // indirect
 	github.com/apache/skywalking-eyes v0.7.0 // indirect
+	github.com/apache/thrift v0.22.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/ashanbrown/forbidigo v1.6.0 // indirect
 	github.com/ashanbrown/makezero v1.2.0 // indirect
@@ -278,6 +279,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
@@ -364,6 +366,7 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/kisielk/errcheck v1.9.0 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
+	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
@@ -395,6 +398,8 @@ require (
 	github.com/mattn/go-mastodon v0.0.9 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mgechev/revive v1.7.0 // indirect
+	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
+	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/internal/filereader/arrow_cooked_reader.go
+++ b/internal/filereader/arrow_cooked_reader.go
@@ -176,8 +176,18 @@ func arrowValue(col arrow.Array, i int) any {
 		return c.Value(i)
 	case *array.Timestamp:
 		tsType := c.DataType().(*arrow.TimestampType)
-		toTime, _ := tsType.GetToTimeFunc()
-		return toTime(c.Value(i))
+		ts := c.Value(i)
+		switch tsType.Unit {
+		case arrow.Second:
+			ts *= 1000
+		case arrow.Millisecond:
+			// already ms
+		case arrow.Microsecond:
+			ts /= 1000
+		case arrow.Nanosecond:
+			ts /= 1000000
+		}
+		return ts
 	default:
 		return nil
 	}

--- a/internal/filereader/arrow_cooked_reader.go
+++ b/internal/filereader/arrow_cooked_reader.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package filereader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+
+	"github.com/cardinalhq/lakerunner/internal/pipeline"
+	"github.com/cardinalhq/lakerunner/internal/pipeline/wkk"
+)
+
+// ArrowCookedReader reads parquet files using Apache Arrow and returns raw rows.
+type ArrowCookedReader struct {
+	pr        *file.Reader
+	fr        *pqarrow.FileReader
+	rr        pqarrow.RecordReader
+	batchSize int
+	rowCount  int64
+	closed    bool
+	exhausted bool
+}
+
+// NewArrowCookedReader creates an ArrowCookedReader for the given parquet.ReaderAtSeeker.
+// The caller is responsible for closing the underlying reader.
+func NewArrowCookedReader(r parquet.ReaderAtSeeker, batchSize int) (*ArrowCookedReader, error) {
+	pf, err := file.NewParquetReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open parquet file: %w", err)
+	}
+
+	props := pqarrow.ArrowReadProperties{BatchSize: int64(batchSize)}
+	fr, err := pqarrow.NewFileReader(pf, props, memory.DefaultAllocator)
+	if err != nil {
+		pf.Close()
+		return nil, fmt.Errorf("failed to create arrow file reader: %w", err)
+	}
+
+	rr, err := fr.GetRecordReader(context.Background(), nil, nil)
+	if err != nil {
+		pf.Close()
+		return nil, fmt.Errorf("failed to create record reader: %w", err)
+	}
+
+	return &ArrowCookedReader{
+		pr:        pf,
+		fr:        fr,
+		rr:        rr,
+		batchSize: batchSize,
+	}, nil
+}
+
+// Next returns the next batch of rows from the parquet file.
+func (r *ArrowCookedReader) Next() (*Batch, error) {
+	if r.closed {
+		return nil, errors.New("reader is closed")
+	}
+	if r.exhausted {
+		return nil, io.EOF
+	}
+
+	rec, err := r.rr.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			r.exhausted = true
+			return nil, io.EOF
+		}
+		return nil, fmt.Errorf("arrow read error: %w", err)
+	}
+	if rec == nil || rec.NumRows() == 0 {
+		r.exhausted = true
+		return nil, io.EOF
+	}
+	defer rec.Release()
+
+	batch := pipeline.GetBatch()
+	fields := rec.Schema().Fields()
+	numRows := int(rec.NumRows())
+
+	for i := 0; i < numRows; i++ {
+		br := batch.AddRow()
+		for j, f := range fields {
+			col := rec.Column(j)
+			if col.IsNull(i) {
+				continue
+			}
+			val := arrowValue(col, i)
+			if val != nil {
+				br[wkk.NewRowKeyFromBytes([]byte(f.Name))] = val
+			}
+		}
+	}
+
+	r.rowCount += int64(numRows)
+	return batch, nil
+}
+
+// Close releases resources associated with the reader.
+func (r *ArrowCookedReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if r.rr != nil {
+		r.rr.Release()
+		r.rr = nil
+	}
+	if r.fr != nil {
+		r.fr = nil
+	}
+	if r.pr != nil {
+		if err := r.pr.Close(); err != nil {
+			return err
+		}
+		r.pr = nil
+	}
+	return nil
+}
+
+// TotalRowsReturned returns the total number of rows successfully returned.
+func (r *ArrowCookedReader) TotalRowsReturned() int64 { return r.rowCount }
+
+// arrowValue converts an Arrow array value at index i to a Go interface{}.
+func arrowValue(col arrow.Array, i int) any {
+	switch c := col.(type) {
+	case *array.Boolean:
+		return c.Value(i)
+	case *array.Int8:
+		return int64(c.Value(i))
+	case *array.Int16:
+		return int64(c.Value(i))
+	case *array.Int32:
+		return int64(c.Value(i))
+	case *array.Int64:
+		return c.Value(i)
+	case *array.Uint8:
+		return uint64(c.Value(i))
+	case *array.Uint16:
+		return uint64(c.Value(i))
+	case *array.Uint32:
+		return uint64(c.Value(i))
+	case *array.Uint64:
+		return c.Value(i)
+	case *array.Float32:
+		return float64(c.Value(i))
+	case *array.Float64:
+		return c.Value(i)
+	case *array.String:
+		return c.Value(i)
+	case *array.LargeString:
+		return c.Value(i)
+	case *array.Binary:
+		return c.Value(i)
+	case *array.LargeBinary:
+		return c.Value(i)
+	case *array.Timestamp:
+		tsType := c.DataType().(*arrow.TimestampType)
+		toTime, _ := tsType.GetToTimeFunc()
+		return toTime(c.Value(i))
+	default:
+		return nil
+	}
+}

--- a/internal/filereader/arrow_cooked_reader_test.go
+++ b/internal/filereader/arrow_cooked_reader_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package filereader
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestArrowCookedReaderWithRealFile verifies the reader can stream rows from a parquet file.
+func TestArrowCookedReaderWithRealFile(t *testing.T) {
+	file, err := os.Open("../../testdata/metrics/metrics-cooked-0001.parquet")
+	require.NoError(t, err)
+	defer file.Close()
+
+	reader, err := NewArrowCookedReader(file, 1000)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	var count int64
+	for {
+		batch, err := reader.Next()
+		if batch != nil {
+			count += int64(batch.Len())
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(211), count)
+}

--- a/internal/filereader/doc.go
+++ b/internal/filereader/doc.go
@@ -49,6 +49,7 @@
 // All format readers return raw, untransformed data from files:
 //
 //   - ParquetRawReader: Generic Parquet files using parquet-go/parquet-go (requires io.ReaderAt)
+//   - ArrowCookedReader: Parquet files via Apache Arrow with streaming record batches
 //   - JSONLinesReader: Streams JSON objects line-by-line from any io.ReadCloser
 //   - ProtoLogsReader: Raw OTEL log records from protobuf
 //   - IngestProtoMetricsReader: Raw OTEL metric data points from protobuf (ingestion only)


### PR DESCRIPTION
## Summary
- add ArrowCookedReader for row-wise parquet streaming via Apache Arrow
- document ArrowCookedReader in filereader docs
- vend Apache Arrow dependency
- exercise ArrowCookedReader against metrics parquet fixture

## Testing
- `go test ./internal/filereader -run TestArrowCookedReaderWithRealFile -count=1 -v`
- `make test` *(fails: interrupted while installing protobuf tools)*
- `make license-check`


------
https://chatgpt.com/codex/tasks/task_e_68b3c827693c83219c078d06a09f0145