### PR TITLE
refactor metrics upload helpers and normalize naming

### DIFF
--- a/internal/metricsprocessing/compaction/coordinate.go
+++ b/internal/metricsprocessing/compaction/coordinate.go
@@ -21,11 +21,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cardinalhq/lakerunner/internal/awsclient"
 	"github.com/cardinalhq/lakerunner/internal/metricsprocessing"
-	"github.com/cardinalhq/lakerunner/internal/parquetwriter"
 	"github.com/cardinalhq/lakerunner/internal/storageprofile"
 	"github.com/cardinalhq/lakerunner/lrdb"
 )
@@ -101,10 +99,7 @@ func coordinate(
 	}
 
 	// Create reader stack for downloading and reading files
-	config := metricsprocessing.ReaderStackConfig{
-		FileSortedCounter: nil, // Telemetry is handled in the generic processor
-		CommonAttributes:  attribute.NewSet(),
-	}
+	config := metricsprocessing.DefaultReaderStackConfig()
 
 	readerStack, err := metricsprocessing.CreateReaderStack(
 		ctx, ll, tmpdir, s3client, metadata.OrganizationID, profile, rows, config)
@@ -173,17 +168,24 @@ func coordinate(
 	s3Ctx, s3Cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer s3Cancel()
 
-	segments, err := uploadCompactedFiles(s3Ctx, ll, s3client, processingResult.RawResults, metadata, profile)
+	segments, err := metricsprocessing.CreateSegmentsFromResults(processingResult.RawResults, metadata.OrganizationID, profile.CollectorName, ll)
+	if err != nil {
+		return fmt.Errorf("failed to create processed segments: %w", err)
+	}
+
+	uploadedSegments, err := metricsprocessing.UploadSegments(s3Ctx, ll, s3client, profile.Bucket, segments)
 	if err != nil {
 		// If upload failed partway through, we need to clean up any uploaded files
-		if len(segments) > 0 {
+		if len(uploadedSegments) > 0 {
 			ll.Warn("S3 upload failed partway through, scheduling cleanup",
-				slog.Int("uploadedFiles", len(segments)),
+				slog.Int("uploadedFiles", len(uploadedSegments)),
 				slog.Any("error", err))
-			segments.ScheduleCleanupAll(ctx, mdb, metadata.OrganizationID, metadata.InstanceNum, profile.Bucket)
+			uploadedSegments.ScheduleCleanupAll(ctx, mdb, metadata.OrganizationID, metadata.InstanceNum, profile.Bucket)
 		}
 		return fmt.Errorf("failed to upload compacted files to S3: %w", err)
 	}
+
+	segments = uploadedSegments
 
 	// Atomically replace segments in database with deadline (5 seconds)
 	dbCtx, dbCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -200,53 +202,6 @@ func coordinate(
 	}
 
 	return nil
-}
-
-func uploadCompactedFiles(
-	ctx context.Context,
-	ll *slog.Logger,
-	s3client *awsclient.S3Client,
-	results []parquetwriter.Result,
-	metadata CompactionWorkMetadata,
-	profile storageprofile.StorageProfile,
-) (metricsprocessing.ProcessedSegments, error) {
-	// Create processed segments from results
-	segments := make(metricsprocessing.ProcessedSegments, 0, len(results))
-
-	for i, result := range results {
-		// Check for context cancellation/timeout before each upload
-		if ctx.Err() != nil {
-			ll.Warn("Upload context cancelled, returning partial results",
-				slog.Int("completedUploads", i),
-				slog.Int("totalFiles", len(results)),
-				slog.Any("error", ctx.Err()))
-			return segments, ctx.Err()
-		}
-
-		segment, err := metricsprocessing.NewProcessedSegment(result, metadata.OrganizationID, profile.CollectorName, ll)
-		if err != nil {
-			return segments, fmt.Errorf("failed to create processed segment: %w", err)
-		}
-
-		if err := segment.UploadToS3(ctx, s3client, profile.Bucket); err != nil {
-			ll.Error("Failed to upload compacted file to S3",
-				slog.String("bucket", profile.Bucket),
-				slog.String("objectID", segment.ObjectID),
-				slog.String("fileName", result.FileName),
-				slog.Int("completedUploads", i),
-				slog.Any("error", err))
-			// Return partial results - the already uploaded files need cleanup
-			return segments, fmt.Errorf("uploading file %s: %w", segment.ObjectID, err)
-		}
-
-		segments = append(segments, segment)
-
-		ll.Debug("Uploaded compacted file to S3",
-			slog.String("objectID", segment.ObjectID),
-			slog.Int64("fileSize", result.FileSize),
-			slog.Int64("recordCount", result.RecordCount))
-	}
-	return segments, nil
 }
 
 func replaceCompactedSegments(

--- a/internal/metricsprocessing/processing.go
+++ b/internal/metricsprocessing/processing.go
@@ -108,6 +108,43 @@ func (ps *ProcessedSegment) GetDateint() int32 {
 // ProcessedSegments is a slice of processed segments with helper methods
 type ProcessedSegments []*ProcessedSegment
 
+// CreateSegmentsFromResults converts parquet writer results into processed segments
+// without uploading them. This is shared between compaction and rollup paths.
+func CreateSegmentsFromResults(results []parquetwriter.Result, orgID uuid.UUID, collectorName string, ll *slog.Logger) (ProcessedSegments, error) {
+	segments := make(ProcessedSegments, 0, len(results))
+	for _, result := range results {
+		segment, err := NewProcessedSegment(result, orgID, collectorName, ll)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create processed segment: %w", err)
+		}
+		segments = append(segments, segment)
+	}
+	return segments, nil
+}
+
+// UploadSegments uploads all provided segments to S3. If an error occurs, the
+// returned slice contains only the successfully uploaded segments so callers can
+// schedule cleanup for them.
+func UploadSegments(ctx context.Context, ll *slog.Logger, s3client *awsclient.S3Client, bucket string, segments ProcessedSegments) (ProcessedSegments, error) {
+	uploaded := make(ProcessedSegments, 0, len(segments))
+	for i, segment := range segments {
+		if ctx.Err() != nil {
+			ll.Warn("Upload context cancelled", slog.Int("completedUploads", i), slog.Int("totalFiles", len(segments)), slog.Any("error", ctx.Err()))
+			return uploaded, ctx.Err()
+		}
+
+		if err := segment.UploadToS3(ctx, s3client, bucket); err != nil {
+			ll.Error("Failed to upload segment", slog.String("bucket", bucket), slog.String("objectID", segment.ObjectID), slog.Int("completedUploads", i), slog.Any("error", err))
+			return uploaded, fmt.Errorf("uploading file %s: %w", segment.ObjectID, err)
+		}
+
+		uploaded = append(uploaded, segment)
+
+		ll.Debug("Uploaded segment to S3", slog.String("objectID", segment.ObjectID), slog.Int64("fileSize", segment.Result.FileSize), slog.Int64("recordCount", segment.Result.RecordCount))
+	}
+	return uploaded, nil
+}
+
 // UploadAll uploads all segments to S3, stopping on first error
 func (segments ProcessedSegments) UploadAll(ctx context.Context, s3client *awsclient.S3Client, bucket string) error {
 	for _, segment := range segments {

--- a/internal/metricsprocessing/readerstack.go
+++ b/internal/metricsprocessing/readerstack.go
@@ -39,6 +39,16 @@ type ReaderStackConfig struct {
 	CommonAttributes  attribute.Set
 }
 
+// DefaultReaderStackConfig returns a ReaderStackConfig with no telemetry counters
+// and an empty attribute set. This is the typical configuration for
+// compaction and rollup processing.
+func DefaultReaderStackConfig() ReaderStackConfig {
+	return ReaderStackConfig{
+		FileSortedCounter: nil,
+		CommonAttributes:  attribute.NewSet(),
+	}
+}
+
 type ReaderStackResult struct {
 	Readers         []filereader.Reader
 	Files           []*os.File

--- a/internal/metricsprocessing/rollup/process_batch.go
+++ b/internal/metricsprocessing/rollup/process_batch.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cardinalhq/lakerunner/internal/awsclient"
 	"github.com/cardinalhq/lakerunner/internal/helpers"
@@ -33,8 +32,8 @@ import (
 	"github.com/cardinalhq/lakerunner/lrdb"
 )
 
-// CompactionUploadParams contains parameters for uploading compacted metric files.
-type CompactionUploadParams struct {
+// RollupUploadParams contains parameters for uploading rolled-up metric files.
+type RollupUploadParams struct {
 	OrganizationID uuid.UUID
 	InstanceNum    int16
 	Dateint        int32
@@ -223,10 +222,7 @@ func rollupMetricSegments(
 	}
 
 	// Create reader stack with sorting support
-	config := metricsprocessing.ReaderStackConfig{
-		FileSortedCounter: nil, // Telemetry is handled in the generic processor
-		CommonAttributes:  attribute.NewSet(),
-	}
+	config := metricsprocessing.DefaultReaderStackConfig()
 
 	readerStack, err := metricsprocessing.CreateReaderStack(
 		ctx, ll, tmpdir, s3client, firstSeg.OrganizationID, profile, sourceRows, config)
@@ -299,7 +295,7 @@ func rollupMetricSegments(
 		slog.Int64("outputBytes", processingResult.Stats.OutputBytes),
 		slog.Float64("compressionRatio", compressionRatio))
 
-	rollupParams := CompactionUploadParams{
+	rollupParams := RollupUploadParams{
 		OrganizationID: firstSeg.OrganizationID,
 		InstanceNum:    firstSeg.InstanceNum,
 		Dateint:        firstSeg.Dateint,
@@ -357,16 +353,12 @@ func uploadRolledUpMetricsAtomic(
 	results []parquetwriter.Result,
 	sourceRows []lrdb.MetricSeg,
 	existingRows []lrdb.MetricSeg,
-	params CompactionUploadParams,
+	params RollupUploadParams,
 ) error {
 	// Create processed segments from results
-	segments := make(metricsprocessing.ProcessedSegments, 0, len(results))
-	for _, result := range results {
-		segment, err := metricsprocessing.NewProcessedSegment(result, params.OrganizationID, params.CollectorName, ll)
-		if err != nil {
-			return fmt.Errorf("failed to create processed segment: %w", err)
-		}
-		segments = append(segments, segment)
+	segments, err := metricsprocessing.CreateSegmentsFromResults(results, params.OrganizationID, params.CollectorName, ll)
+	if err != nil {
+		return fmt.Errorf("failed to create processed segment: %w", err)
 	}
 	var targetOldRecords []lrdb.CompactMetricSegsOld
 	for _, row := range existingRows {
@@ -403,8 +395,7 @@ func uploadRolledUpMetricsAtomic(
 			slog.String("bucket", params.Bucket),
 			slog.Int64("newSegmentID", segment.SegmentID))
 
-		err := segment.UploadToS3(ctx, s3client, params.Bucket)
-		if err != nil {
+		if _, err := metricsprocessing.UploadSegments(ctx, fileLogger, s3client, params.Bucket, metricsprocessing.ProcessedSegments{segment}); err != nil {
 			fileLogger.Error("Atomic operation failed during S3 upload - no changes made",
 				slog.Any("error", err),
 				slog.String("objectID", segment.ObjectID))


### PR DESCRIPTION
## Summary
- centralize reader stack defaults with a new helper
- add reusable helpers for building and uploading processed metric segments
- normalize rollup naming and use common upload helpers

## Testing
- `make check` *(fails: create table: failed to get duckdb connection: failed to load extension 'httpfs')*


------
https://chatgpt.com/codex/tasks/task_e_68b6a21799d88321b045d10b620d0efd