### PR TITLE
feat: add cooked parquet reader factories

### DIFF
--- a/internal/filereader/cooked_parquet_reader_factory.go
+++ b/internal/filereader/cooked_parquet_reader_factory.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package filereader
+
+import "io"
+
+// NewCookedMetricParquetReader creates a reader for cooked metric parquet files.
+// It wraps a ParquetRawReader with CookedMetricTranslatingReader to apply
+// metric-specific filtering and transformations.
+func NewCookedMetricParquetReader(r io.ReaderAt, size int64, batchSize int) (Reader, error) {
+	raw, err := NewParquetRawReader(r, size, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	return NewCookedMetricTranslatingReader(raw), nil
+}
+
+// NewCookedLogParquetReader creates a reader for cooked log parquet files.
+// It wraps a ParquetRawReader with CookedLogTranslatingReader to apply
+// log-specific filtering and transformations.
+func NewCookedLogParquetReader(r io.ReaderAt, size int64, batchSize int) (Reader, error) {
+	raw, err := NewParquetRawReader(r, size, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	return NewCookedLogTranslatingReader(raw), nil
+}

--- a/internal/filereader/cooked_parquet_reader_factory_test.go
+++ b/internal/filereader/cooked_parquet_reader_factory_test.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package filereader
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cardinalhq/lakerunner/internal/pipeline/wkk"
+)
+
+func TestNewCookedMetricParquetReader(t *testing.T) {
+	filename := "../../testdata/metrics/compact-test-0001/tbl_299476441865651503.parquet"
+	file, err := os.Open(filename)
+	require.NoError(t, err)
+	defer file.Close()
+
+	stat, err := file.Stat()
+	require.NoError(t, err)
+
+	reader, err := NewCookedMetricParquetReader(file, stat.Size(), 1000)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	var count int64
+	for {
+		batch, err := reader.Next(context.Background())
+		if batch != nil {
+			count += int64(batch.Len())
+		}
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	// One NaN row should be dropped by the translating reader
+	assert.Equal(t, int64(226), count)
+}
+
+func TestNewCookedLogParquetReader(t *testing.T) {
+	filename := "../../testdata/logs/logs-cooked-0001.parquet"
+	file, err := os.Open(filename)
+	require.NoError(t, err)
+	defer file.Close()
+
+	stat, err := file.Stat()
+	require.NoError(t, err)
+
+	reader, err := NewCookedLogParquetReader(file, stat.Size(), 1000)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	batch, err := reader.Next(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+
+	found := false
+	for i := 0; i < batch.Len(); i++ {
+		row := batch.Get(i)
+		if tidVal, ok := row[wkk.RowKeyCTID]; ok {
+			_, isInt64 := tidVal.(int64)
+			assert.True(t, isInt64)
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected row with _cardinalhq.tid")
+}

--- a/internal/filereader/reader_factory.go
+++ b/internal/filereader/reader_factory.go
@@ -121,7 +121,6 @@ func ReaderForFileWithOptions(filename string, opts ReaderOptions) (Reader, erro
 }
 
 // createParquetReader creates a ParquetRawReader for the given file.
-// For cooked parquet files (metrics/logs), it wraps the reader with the appropriate translating reader.
 func createParquetReader(filename string, opts ReaderOptions) (Reader, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -138,21 +137,6 @@ func createParquetReader(filename string, opts ReaderOptions) (Reader, error) {
 	if err != nil {
 		file.Close()
 		return nil, err
-	}
-
-	// Check if this is a cooked parquet file and wrap with appropriate translator
-	// Cooked files contain opinionated metric/log formats that need transformation
-	// Only apply translator for files that explicitly contain "cooked" in the name
-	if strings.Contains(filename, "cooked") {
-		switch opts.SignalType {
-		case SignalTypeMetrics:
-			return NewCookedMetricTranslatingReader(reader), nil
-		case SignalTypeLogs:
-			return NewCookedLogTranslatingReader(reader), nil
-		default:
-			// For traces or unknown types, return raw reader
-			return reader, nil
-		}
 	}
 
 	return reader, nil

--- a/internal/metricsprocessing/readerstack.go
+++ b/internal/metricsprocessing/readerstack.go
@@ -98,7 +98,7 @@ func CreateReaderStack(
 			return nil, fmt.Errorf("statting parquet file %s: %w", fn, err)
 		}
 
-		reader, err := filereader.NewParquetRawReader(file, stat.Size(), 1000)
+		reader, err := filereader.NewCookedMetricParquetReader(file, stat.Size(), 1000)
 		if err != nil {
 			file.Close()
 			ll.Error("Failed to create parquet reader", slog.String("file", fn), slog.Any("error", err))


### PR DESCRIPTION
## Summary
- add dedicated cooked parquet reader constructors for metrics and logs
- wrap metric segment readers with cooked translation
- remove filename heuristics from parquet reader factory

## Testing
- `make check` *(fails: failed to download duckdb httpfs extension)*


------
https://chatgpt.com/codex/tasks/task_e_68bc1c1eb5a483219bed6102728f9652