### PR TITLE
feat: add file-based cloud storage client for tests

### DIFF
--- a/internal/cloudstorage/file_client.go
+++ b/internal/cloudstorage/file_client.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package cloudstorage
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cardinalhq/lakerunner/internal/storageprofile"
+)
+
+// FileClientProvider creates clients that operate on the local filesystem.
+// It is intended for tests that want to bypass real cloud providers.
+type FileClientProvider struct {
+	base string
+}
+
+// NewFileClientProvider returns a new provider rooted at base.
+func NewFileClientProvider(base string) ClientProvider {
+	return &FileClientProvider{base: base}
+}
+
+// NewClient returns a client that reads and writes files under the base path.
+func (p *FileClientProvider) NewClient(ctx context.Context, profile storageprofile.StorageProfile) (Client, error) {
+	// Bucket names become subdirectories under the base path.
+	return &fileClient{base: p.base}, nil
+}
+
+type fileClient struct {
+	base string
+}
+
+func (c *fileClient) path(bucket, key string) string {
+	return filepath.Join(c.base, bucket, filepath.FromSlash(key))
+}
+
+// DownloadObject copies the requested object to a temp file and returns the filename.
+func (c *fileClient) DownloadObject(ctx context.Context, tmpdir, bucket, key string) (string, int64, bool, error) {
+	src := c.path(bucket, key)
+	fi, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", 0, true, nil
+		}
+		return "", 0, false, err
+	}
+	dst, err := os.CreateTemp(tmpdir, "lr-file-*")
+	if err != nil {
+		return "", 0, false, err
+	}
+	defer dst.Close()
+
+	f, err := os.Open(src)
+	if err != nil {
+		return "", 0, false, err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(dst, f); err != nil {
+		return "", 0, false, err
+	}
+	return dst.Name(), fi.Size(), false, nil
+}
+
+// UploadObject copies a local file into the bucket/key location.
+func (c *fileClient) UploadObject(ctx context.Context, bucket, key, sourceFilename string) error {
+	dst := c.path(bucket, key)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	src, err := os.Open(sourceFilename)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, src)
+	return err
+}
+
+// DeleteObject removes the file at bucket/key if it exists.
+func (c *fileClient) DeleteObject(ctx context.Context, bucket, key string) error {
+	path := c.path(bucket, key)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/cloudstorage/file_client_test.go
+++ b/internal/cloudstorage/file_client_test.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package cloudstorage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cardinalhq/lakerunner/internal/storageprofile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileClientLifecycle(t *testing.T) {
+	base := t.TempDir()
+	provider := NewFileClientProvider(base)
+	client, err := provider.NewClient(context.Background(), storageprofile.StorageProfile{})
+	require.NoError(t, err)
+
+	// Create source file
+	src := filepath.Join(base, "src.txt")
+	require.NoError(t, os.WriteFile(src, []byte("hello"), 0o644))
+
+	// Upload to bucket/key
+	require.NoError(t, client.UploadObject(context.Background(), "bucket", "path/file.txt", src))
+
+	// Download and verify
+	tmp := t.TempDir()
+	dst, size, notFound, err := client.DownloadObject(context.Background(), tmp, "bucket", "path/file.txt")
+	require.NoError(t, err)
+	require.False(t, notFound)
+	require.Equal(t, int64(5), size)
+	data, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(data))
+
+	// Delete
+	require.NoError(t, client.DeleteObject(context.Background(), "bucket", "path/file.txt"))
+	_, _, notFound, err = client.DownloadObject(context.Background(), tmp, "bucket", "path/file.txt")
+	require.NoError(t, err)
+	require.True(t, notFound)
+}


### PR DESCRIPTION
## Summary
- add local filesystem-backed cloud storage client and provider for test use
- cover file client lifecycle with unit test

## Testing
- `go test ./internal/cloudstorage -run FileClient -count=1`
- `make check` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2fd6d7d88321a5ac03465813aa85