### PR TITLE
fix: guard Kafka factory reflection

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,73 @@
+# Environment Variable Changes
+
+The following environment variables were added or removed in this branch. Update Helm charts and values accordingly.
+
+## Added
+- `LAKERUNNER_KAFKA_TOPIC_PREFIX` – optional override for Kafka topic prefix.
+
+```yaml
+# config.yaml
+kafka_topics:
+  topicPrefix: lakerunner
+```
+
+```bash
+# override
+LAKERUNNER_KAFKA_TOPIC_PREFIX=my-prefix
+```
+
+## Removed / Replaced
+
+### `DEBUG`
+Use `LAKERUNNER_DEBUG` or the `debug` config setting.
+
+```yaml
+# config.yaml
+debug: true
+```
+
+```bash
+LAKERUNNER_DEBUG=true
+```
+
+### `LAKERUNNER_AZURE_EXTENSION`
+Azure extension path now configured via `duckdb.azure_extension` in config.
+
+```yaml
+# config.yaml
+duckdb:
+  azure_extension: /opt/duckdb/azure.duckdb_extension
+```
+
+```bash
+LAKERUNNER_DUCKDB_AZURE_EXTENSION=/opt/duckdb/azure.duckdb_extension
+```
+
+### `LAKERUNNER_FLY_BROKERS`
+Kafka brokers now set via `kafka.brokers` in config.
+
+```yaml
+# config.yaml
+kafka:
+  brokers:
+    - broker1:9092
+    - broker2:9092
+```
+
+```bash
+LAKERUNNER_KAFKA_BROKERS=broker1:9092,broker2:9092
+```
+
+### `LAKERUNNER_INITIAL_ADMIN_API_KEY`
+Initial admin key now specified via `admin.initial_api_key` in config.
+
+```yaml
+# config.yaml
+admin:
+  initial_api_key: supersecret
+```
+
+```bash
+LAKERUNNER_ADMIN_INITIAL_API_KEY=supersecret
+```
+

--- a/cmd/boxer_compact_logs.go
+++ b/cmd/boxer_compact_logs.go
@@ -81,7 +81,10 @@ func init() {
 			}
 
 			// Create Kafka factory
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			// Create Kafka-based compaction boxer consumer
 			consumer, err := metricsprocessing.NewLogCompactionBoxerConsumer(ctx, kafkaFactory, cfg, mdb)

--- a/cmd/boxer_compact_metrics.go
+++ b/cmd/boxer_compact_metrics.go
@@ -81,7 +81,10 @@ func init() {
 			}
 
 			// Create Kafka factory
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			// Create Kafka-based compaction boxer consumer
 			consumer, err := metricsprocessing.NewMetricCompactionBoxerConsumer(ctx, kafkaFactory, mdb, cfg)

--- a/cmd/boxer_compact_traces.go
+++ b/cmd/boxer_compact_traces.go
@@ -81,7 +81,10 @@ func init() {
 			}
 
 			// Create Kafka factory
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			// Create Kafka-based compaction boxer consumer
 			consumer, err := metricsprocessing.NewTraceCompactionBoxerConsumer(ctx, kafkaFactory, mdb, cfg)

--- a/cmd/boxer_rollup_metrics.go
+++ b/cmd/boxer_rollup_metrics.go
@@ -81,7 +81,10 @@ func init() {
 			}
 
 			// Create Kafka factory
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			// Create Kafka-based boxer consumer
 			consumer, err := metricsprocessing.NewMetricBoxerConsumer(ctx, kafkaFactory, mdb, cfg)

--- a/cmd/compact_logs.go
+++ b/cmd/compact_logs.go
@@ -94,7 +94,10 @@ func init() {
 			ll := logctx.FromContext(ctx).With("instanceID", myInstanceID)
 			ctx = logctx.WithLogger(ctx, ll)
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			slog.Info("Starting log compaction with bundle consumer")
 
 			consumer, err := metricsprocessing.NewLogCompactionConsumer(ctx, kafkaFactory, cfg, mdb, sp, cmgr)

--- a/cmd/compact_metrics.go
+++ b/cmd/compact_metrics.go
@@ -94,7 +94,10 @@ func init() {
 			ll := logctx.FromContext(ctx).With("instanceID", myInstanceID)
 			ctx = logctx.WithLogger(ctx, ll)
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			slog.Info("Starting metrics compaction consumer")
 
 			consumer, err := metricsprocessing.NewMetricCompactionConsumer(ctx, cfg, kafkaFactory, mdb, sp, cmgr)

--- a/cmd/compact_traces.go
+++ b/cmd/compact_traces.go
@@ -94,7 +94,10 @@ func init() {
 			ll := logctx.FromContext(ctx).With("instanceID", myInstanceID)
 			ctx = logctx.WithLogger(ctx, ll)
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			slog.Info("Starting trace compaction consumer")
 
 			consumer, err := metricsprocessing.NewTraceCompactionConsumer(ctx, cfg, kafkaFactory, mdb, sp, cmgr)

--- a/cmd/debug/kafka.go
+++ b/cmd/debug/kafka.go
@@ -74,7 +74,10 @@ func getConsumerLagCmd() *cobra.Command {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			factory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			factory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
@@ -333,7 +336,10 @@ Examples:
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			factory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			factory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/ingest_logs.go
+++ b/cmd/ingest_logs.go
@@ -94,7 +94,10 @@ func init() {
 			ll := logctx.FromContext(ctx).With("instanceID", myInstanceID)
 			ctx = logctx.WithLogger(ctx, ll)
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			slog.Info("Starting logs ingestion with accumulation consumer")
 
 			consumer, err := metricsprocessing.NewLogIngestConsumer(ctx, kafkaFactory, cfg, mdb, sp, cmgr)

--- a/cmd/ingest_metrics.go
+++ b/cmd/ingest_metrics.go
@@ -94,7 +94,10 @@ func init() {
 			ll := logctx.FromContext(ctx).With("instanceID", myInstanceID)
 			ctx = logctx.WithLogger(ctx, ll)
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			slog.Info("Starting metrics ingestion with accumulation consumer")
 
 			consumer, err := metricsprocessing.NewMetricIngestConsumer(ctx, kafkaFactory, cfg, mdb, sp, cmgr)

--- a/cmd/ingest_traces.go
+++ b/cmd/ingest_traces.go
@@ -94,7 +94,10 @@ func init() {
 			ll := logctx.FromContext(ctx).With("instanceID", myInstanceID)
 			ctx = logctx.WithLogger(ctx, ll)
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			slog.Info("Starting traces ingestion with accumulation consumer")
 
 			consumer, err := metricsprocessing.NewTraceIngestConsumer(ctx, kafkaFactory, cfg, mdb, sp, cmgr)

--- a/cmd/kafka_topics.go
+++ b/cmd/kafka_topics.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/cardinalhq/kafka-sync/kafkasync"
+
 	"github.com/cardinalhq/lakerunner/config"
 	"github.com/cardinalhq/lakerunner/internal/fly"
 )
@@ -33,7 +34,10 @@ func ensureKafkaTopicsWithFile(ctx context.Context, flagKafkaTopicsFile string) 
 	}
 
 	// Create topic syncer
-	factory := fly.NewFactoryFromKafkaConfig(&appConfig.Kafka)
+	factory, err := fly.NewFactoryFromKafkaConfig(&appConfig.Kafka)
+	if err != nil {
+		return fmt.Errorf("failed to create Kafka factory: %w", err)
+	}
 	syncer := factory.CreateTopicSyncer()
 
 	var topicsConfig *kafkasync.Config

--- a/cmd/pubsub.go
+++ b/cmd/pubsub.go
@@ -58,7 +58,10 @@ func init() {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			service, err := pubsub.NewHTTPService(doneCtx, cfg, kafkaFactory)
 			if err != nil {
 				return fmt.Errorf("failed to create HTTP pubsub service: %w", err)
@@ -93,7 +96,10 @@ func init() {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			service, err := pubsub.NewSQSService(doneCtx, cfg, kafkaFactory)
 			if err != nil {
 				return fmt.Errorf("failed to create SQS pubsub service: %w", err)
@@ -127,7 +133,10 @@ func init() {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 			backend, err := pubsub.NewBackend(doneCtx, cfg, pubsub.BackendTypeGCPPubSub, kafkaFactory)
 			if err != nil {
 				return fmt.Errorf("failed to create GCP Pub/Sub backend: %w", err)
@@ -162,7 +171,10 @@ func init() {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			backend, err := pubsub.NewBackend(doneCtx, cfg, pubsub.BackendTypeAzure, kafkaFactory)
 			if err != nil {

--- a/cmd/rollup_metrics.go
+++ b/cmd/rollup_metrics.go
@@ -94,7 +94,10 @@ func init() {
 			}
 
 			// Create Kafka factory
-			kafkaFactory := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			kafkaFactory, err := fly.NewFactoryFromKafkaConfig(&cfg.Kafka)
+			if err != nil {
+				return fmt.Errorf("failed to create Kafka factory: %w", err)
+			}
 
 			// Create Kafka-based rollup consumer (now consumes bundles from boxer)
 			consumer, err := metricsprocessing.NewMetricRollupConsumer(ctx, cfg, kafkaFactory, mdb, sp, cmgr)

--- a/internal/fly/factory.go
+++ b/internal/fly/factory.go
@@ -39,30 +39,64 @@ func NewFactory(config *Config) *Factory {
 	}
 }
 
-// NewFactoryFromKafkaConfig creates a new factory from a config.KafkaConfig
-// This avoids import cycles while allowing the main config package to use this factory
-func NewFactoryFromKafkaConfig(kafkaConfig interface{}) *Factory {
-	// Use reflection to convert config.KafkaConfig to fly.Config
-	// This is safe because both structs have identical fields
-	cfg := &Config{
-		Brokers:              getStringSlice(kafkaConfig, "Brokers"),
-		SASLEnabled:          getBool(kafkaConfig, "SASLEnabled"),
-		SASLMechanism:        getString(kafkaConfig, "SASLMechanism"),
-		SASLUsername:         getString(kafkaConfig, "SASLUsername"),
-		SASLPassword:         getString(kafkaConfig, "SASLPassword"),
-		TLSEnabled:           getBool(kafkaConfig, "TLSEnabled"),
-		TLSSkipVerify:        getBool(kafkaConfig, "TLSSkipVerify"),
-		ProducerBatchSize:    getInt(kafkaConfig, "ProducerBatchSize"),
-		ProducerBatchTimeout: getDuration(kafkaConfig, "ProducerBatchTimeout"),
-		ProducerCompression:  getString(kafkaConfig, "ProducerCompression"),
-		ConsumerGroupPrefix:  getString(kafkaConfig, "ConsumerGroupPrefix"),
-		ConsumerBatchSize:    getInt(kafkaConfig, "ConsumerBatchSize"),
-		ConsumerMaxWait:      getDuration(kafkaConfig, "ConsumerMaxWait"),
-		ConsumerMinBytes:     getInt(kafkaConfig, "ConsumerMinBytes"),
-		ConsumerMaxBytes:     getInt(kafkaConfig, "ConsumerMaxBytes"),
-		ConnectionTimeout:    getDuration(kafkaConfig, "ConnectionTimeout"),
+// NewFactoryFromKafkaConfig creates a new factory from a config.KafkaConfig.
+// Reflection is used to avoid import cycles with the main config package.
+// The function validates the presence and types of expected fields to prevent
+// runtime panics if the source struct changes.
+func NewFactoryFromKafkaConfig(kafkaConfig interface{}) (*Factory, error) {
+	cfg := &Config{}
+	var err error
+
+	if cfg.Brokers, err = getStringSlice(kafkaConfig, "Brokers"); err != nil {
+		return nil, err
 	}
-	return &Factory{config: cfg}
+	if cfg.SASLEnabled, err = getBool(kafkaConfig, "SASLEnabled"); err != nil {
+		return nil, err
+	}
+	if cfg.SASLMechanism, err = getString(kafkaConfig, "SASLMechanism"); err != nil {
+		return nil, err
+	}
+	if cfg.SASLUsername, err = getString(kafkaConfig, "SASLUsername"); err != nil {
+		return nil, err
+	}
+	if cfg.SASLPassword, err = getString(kafkaConfig, "SASLPassword"); err != nil {
+		return nil, err
+	}
+	if cfg.TLSEnabled, err = getBool(kafkaConfig, "TLSEnabled"); err != nil {
+		return nil, err
+	}
+	if cfg.TLSSkipVerify, err = getBool(kafkaConfig, "TLSSkipVerify"); err != nil {
+		return nil, err
+	}
+	if cfg.ProducerBatchSize, err = getInt(kafkaConfig, "ProducerBatchSize"); err != nil {
+		return nil, err
+	}
+	if cfg.ProducerBatchTimeout, err = getDuration(kafkaConfig, "ProducerBatchTimeout"); err != nil {
+		return nil, err
+	}
+	if cfg.ProducerCompression, err = getString(kafkaConfig, "ProducerCompression"); err != nil {
+		return nil, err
+	}
+	if cfg.ConsumerGroupPrefix, err = getString(kafkaConfig, "ConsumerGroupPrefix"); err != nil {
+		return nil, err
+	}
+	if cfg.ConsumerBatchSize, err = getInt(kafkaConfig, "ConsumerBatchSize"); err != nil {
+		return nil, err
+	}
+	if cfg.ConsumerMaxWait, err = getDuration(kafkaConfig, "ConsumerMaxWait"); err != nil {
+		return nil, err
+	}
+	if cfg.ConsumerMinBytes, err = getInt(kafkaConfig, "ConsumerMinBytes"); err != nil {
+		return nil, err
+	}
+	if cfg.ConsumerMaxBytes, err = getInt(kafkaConfig, "ConsumerMaxBytes"); err != nil {
+		return nil, err
+	}
+	if cfg.ConnectionTimeout, err = getDuration(kafkaConfig, "ConnectionTimeout"); err != nil {
+		return nil, err
+	}
+
+	return &Factory{config: cfg}, nil
 }
 
 // CreateProducer creates a new Kafka producer
@@ -317,51 +351,66 @@ func (m *Manager) Close() error {
 }
 
 // Reflection helper functions for NewFactoryFromKafkaConfig
-func getString(obj interface{}, field string) string {
+func getString(obj interface{}, field string) (string, error) {
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 	f := v.FieldByName(field)
-	return f.String()
+	if !f.IsValid() || f.Kind() != reflect.String {
+		return "", fmt.Errorf("missing or non-string field %s", field)
+	}
+	return f.String(), nil
 }
 
-func getBool(obj interface{}, field string) bool {
+func getBool(obj interface{}, field string) (bool, error) {
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 	f := v.FieldByName(field)
-	return f.Bool()
+	if !f.IsValid() || f.Kind() != reflect.Bool {
+		return false, fmt.Errorf("missing or non-bool field %s", field)
+	}
+	return f.Bool(), nil
 }
 
-func getInt(obj interface{}, field string) int {
+func getInt(obj interface{}, field string) (int, error) {
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 	f := v.FieldByName(field)
-	return int(f.Int())
+	if !f.IsValid() || f.Kind() != reflect.Int {
+		return 0, fmt.Errorf("missing or non-int field %s", field)
+	}
+	return int(f.Int()), nil
 }
 
-func getDuration(obj interface{}, field string) time.Duration {
+func getDuration(obj interface{}, field string) (time.Duration, error) {
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 	f := v.FieldByName(field)
-	return time.Duration(f.Int())
+	if !f.IsValid() || f.Type() != reflect.TypeOf(time.Duration(0)) {
+		return 0, fmt.Errorf("missing or non-duration field %s", field)
+	}
+	return time.Duration(f.Int()), nil
 }
 
-func getStringSlice(obj interface{}, field string) []string {
+func getStringSlice(obj interface{}, field string) ([]string, error) {
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 	f := v.FieldByName(field)
+	if !f.IsValid() || f.Kind() != reflect.Slice || f.Type().Elem().Kind() != reflect.String {
+		return nil, fmt.Errorf("missing or non-string slice field %s", field)
+	}
 	result := make([]string, f.Len())
 	for i := 0; i < f.Len(); i++ {
 		result[i] = f.Index(i).String()
 	}
-	return result
+	return result, nil
 }

--- a/internal/fly/factory_test.go
+++ b/internal/fly/factory_test.go
@@ -218,6 +218,25 @@ func TestFactory_CreateConsumerWithService(t *testing.T) {
 	_ = consumer.Close()
 }
 
+func TestNewFactoryFromKafkaConfig_Success(t *testing.T) {
+	cfg := &Config{
+		Brokers: []string{"localhost:9092"},
+	}
+
+	factory, err := NewFactoryFromKafkaConfig(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, cfg.Brokers, factory.GetConfig().Brokers)
+}
+
+func TestNewFactoryFromKafkaConfig_Invalid(t *testing.T) {
+	type BadConfig struct {
+		Brokers string
+	}
+
+	_, err := NewFactoryFromKafkaConfig(&BadConfig{Brokers: "localhost:9092"})
+	require.Error(t, err)
+}
+
 func TestManager_Lifecycle(t *testing.T) {
 	config := &Config{
 		Brokers:           []string{"localhost:9092"},


### PR DESCRIPTION
## Summary
- add field validation to `NewFactoryFromKafkaConfig` and propagate errors to callers
- document environment variable changes without reflection rationale

## Testing
- `make test` *(interrupted: signal)*
- `make test-only` *(interrupted during link)*
- `go test ./internal/fly -run NewFactoryFromKafkaConfig -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68c64dc805348321a8e4175097cc99f2