### PR TITLE
feat: add option to write to lowest instance

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"strings"
@@ -30,15 +31,14 @@ import (
 type Config struct {
 	Debug       bool              `mapstructure:"debug"`
 	Kafka       KafkaConfig       `mapstructure:"kafka"`
+	KafkaTopics KafkaTopicsConfig `mapstructure:"kafka_topics"`
 	Metrics     MetricsConfig     `mapstructure:"metrics"`
-	Batch       BatchConfig       `mapstructure:"batch"`
+	Logs        LogsConfig        `mapstructure:"logs"`
+	Traces      TracesConfig      `mapstructure:"traces"`
 	DuckDB      DuckDBConfig      `mapstructure:"duckdb"`
 	S3          S3Config          `mapstructure:"s3"`
 	Azure       AzureConfig       `mapstructure:"azure"`
-	Logs        LogsConfig        `mapstructure:"logs"`
-	Traces      TracesConfig      `mapstructure:"traces"`
 	Admin       AdminConfig       `mapstructure:"admin"`
-	KafkaTopics KafkaTopicsConfig `mapstructure:"kafka_topics"`
 	Scaling     ScalingConfig     `mapstructure:"scaling"`
 
 	// Derived fields (populated during Load())
@@ -46,17 +46,15 @@ type Config struct {
 }
 
 type MetricsConfig struct {
-	Ingestion  IngestionConfig  `mapstructure:"ingestion"`
-	Compaction CompactionConfig `mapstructure:"compaction"`
-	Rollup     RollupConfig     `mapstructure:"rollup"`
+	Ingestion IngestionConfig `mapstructure:"ingestion"`
 }
 
-type BatchConfig struct {
-	TargetSizeBytes int64 `mapstructure:"target_size_bytes"`
-	MaxBatchSize    int   `mapstructure:"max_batch_size"`
-	MaxTotalSize    int64 `mapstructure:"max_total_size"`
-	MaxAgeSeconds   int   `mapstructure:"max_age_seconds"`
-	MinBatchSize    int   `mapstructure:"min_batch_size"`
+type LogsConfig struct {
+	Ingestion IngestionConfig `mapstructure:"ingestion"`
+}
+
+type TracesConfig struct {
+	Ingestion IngestionConfig `mapstructure:"ingestion"`
 }
 
 type S3Config struct {
@@ -75,16 +73,6 @@ type AzureConfig struct {
 	ConnectionString string `mapstructure:"connection_string"`
 }
 
-type LogsConfig struct {
-	Ingestion IngestionConfig `mapstructure:"ingestion"`
-	// Partitions will be auto-determined from Kafka topic
-}
-
-type TracesConfig struct {
-	Ingestion IngestionConfig `mapstructure:"ingestion"`
-	// Partitions will be auto-determined from Kafka topic
-}
-
 type AdminConfig struct {
 	InitialAPIKey string `mapstructure:"initial_api_key"`
 }
@@ -92,9 +80,9 @@ type AdminConfig struct {
 // TopicCreationConfig holds configuration for creating Kafka topics
 // WARNING: These settings are for topic creation only - never use partition counts in runtime code
 type TopicCreationConfig struct {
-	PartitionCount    *int                   `mapstructure:"partitionCount"`
-	ReplicationFactor *int                   `mapstructure:"replicationFactor"`
-	Options           map[string]interface{} `mapstructure:"options"`
+	PartitionCount    *int           `mapstructure:"partitionCount"`
+	ReplicationFactor *int           `mapstructure:"replicationFactor"`
+	Options           map[string]any `mapstructure:"options"`
 }
 
 type KafkaTopicsConfig struct {
@@ -114,9 +102,9 @@ type KafkaTopicsOverrideVersionCheck struct {
 // TopicCreationOverrideConfig holds configuration for creating Kafka topics in override files
 // Uses yaml tags instead of mapstructure tags
 type TopicCreationOverrideConfig struct {
-	PartitionCount    *int                   `yaml:"partitionCount"`
-	ReplicationFactor *int                   `yaml:"replicationFactor"`
-	Options           map[string]interface{} `yaml:"options"`
+	PartitionCount    *int           `yaml:"partitionCount"`
+	ReplicationFactor *int           `yaml:"replicationFactor"`
+	Options           map[string]any `yaml:"options"`
 }
 
 // KafkaTopicsOverrideConfig is the full structure for external YAML override files
@@ -158,30 +146,13 @@ type KafkaConfig struct {
 }
 
 type CompactionConfig struct {
-	TargetFileSizeBytes int64         `mapstructure:"target_file_size_bytes"` // Target file size in bytes for compaction (default: 1048576 = 1MB)
-	MaxAccumulationTime time.Duration `mapstructure:"max_accumulation_time"`  // Maximum time to accumulate segments before compacting
-}
-
-type RollupConfig struct {
-	BatchLimit int `mapstructure:"batch_limit"`
+	TargetFileSizeBytes int64 `mapstructure:"target_file_size_bytes"` // Target file size in bytes for compaction (default: 1048576 = 1MB)
 }
 
 // IngestionConfig holds ingestion feature toggles.
 type IngestionConfig struct {
-	ProcessExemplars      bool          `mapstructure:"process_exemplars"`
-	SingleInstanceMode    bool          `mapstructure:"single_instance_mode"`
-	MaxAccumulationTime   time.Duration `mapstructure:"max_accumulation_time"`
-	WriteToLowestInstance bool          `mapstructure:"write_to_lowest_instance"`
-}
-
-// DefaultIngestionConfig returns default settings for ingestion.
-func DefaultIngestionConfig() IngestionConfig {
-	return IngestionConfig{
-		ProcessExemplars:      true,
-		SingleInstanceMode:    false,
-		MaxAccumulationTime:   10 * time.Second,
-		WriteToLowestInstance: false,
-	}
+	ProcessExemplars   bool `mapstructure:"process_exemplars"`
+	SingleInstanceMode bool `mapstructure:"single_instance_mode"`
 }
 
 // GetConsumerGroup returns the consumer group name for the given service
@@ -225,21 +196,10 @@ func Load() (*Config, error) {
 		Debug: false,
 		Kafka: DefaultKafkaConfig(),
 		Metrics: MetricsConfig{
-			Ingestion: DefaultIngestionConfig(),
-			Compaction: CompactionConfig{
-				TargetFileSizeBytes: TargetFileSize,   // Default target file size
-				MaxAccumulationTime: 30 * time.Second, // Default 30 seconds for compaction
+			Ingestion: IngestionConfig{
+				ProcessExemplars:   true,
+				SingleInstanceMode: false,
 			},
-			Rollup: RollupConfig{
-				BatchLimit: 100,
-			},
-		},
-		Batch: BatchConfig{
-			TargetSizeBytes: 100 * 1024 * 1024, // 100MB
-			MaxBatchSize:    100,
-			MaxTotalSize:    1024 * 1024 * 1024, // 1GB
-			MaxAgeSeconds:   300,                // 5 minutes
-			MinBatchSize:    1,
 		},
 		DuckDB:  DefaultDuckDBConfig(),
 		Scaling: GetDefaultScalingConfig(),
@@ -257,8 +217,18 @@ func Load() (*Config, error) {
 			TenantID:         "",
 			ConnectionString: "",
 		},
-		Logs:   LogsConfig{Ingestion: DefaultIngestionConfig()},
-		Traces: TracesConfig{Ingestion: DefaultIngestionConfig()},
+		Logs: LogsConfig{
+			Ingestion: IngestionConfig{
+				ProcessExemplars:   true,
+				SingleInstanceMode: false,
+			},
+		},
+		Traces: TracesConfig{
+			Ingestion: IngestionConfig{
+				ProcessExemplars:   true,
+				SingleInstanceMode: false,
+			},
+		},
 		Admin: AdminConfig{
 			InitialAPIKey: "",
 		},
@@ -478,12 +448,7 @@ func MergeKafkaTopicsOverride(base KafkaTopicsConfig, override *KafkaTopicsOverr
 		Topics:      make(map[string]TopicCreationConfig),
 	}
 
-	// Copy base topics
-	for k, v := range base.Topics {
-		result.Topics[k] = v
-	}
-
-	// Note: TopicPrefix is NOT overridden - it comes from main config or environment
+	maps.Copy(result.Topics, base.Topics)
 
 	// Merge defaults (override takes precedence for non-nil values)
 	if override.Defaults.PartitionCount != nil {
@@ -496,9 +461,7 @@ func MergeKafkaTopicsOverride(base KafkaTopicsConfig, override *KafkaTopicsOverr
 		if result.Defaults.Options == nil {
 			result.Defaults.Options = make(map[string]interface{})
 		}
-		for k, v := range override.Defaults.Options {
-			result.Defaults.Options[k] = v
-		}
+		maps.Copy(result.Defaults.Options, override.Defaults.Options)
 	}
 
 	// Merge per-topic configs (override completely replaces base for each topic)

--- a/config/config.go
+++ b/config/config.go
@@ -76,10 +76,12 @@ type AzureConfig struct {
 }
 
 type LogsConfig struct {
+	Ingestion IngestionConfig `mapstructure:"ingestion"`
 	// Partitions will be auto-determined from Kafka topic
 }
 
 type TracesConfig struct {
+	Ingestion IngestionConfig `mapstructure:"ingestion"`
 	// Partitions will be auto-determined from Kafka topic
 }
 
@@ -166,17 +168,19 @@ type RollupConfig struct {
 
 // IngestionConfig holds ingestion feature toggles.
 type IngestionConfig struct {
-	ProcessExemplars    bool          `mapstructure:"process_exemplars"`
-	SingleInstanceMode  bool          `mapstructure:"single_instance_mode"`
-	MaxAccumulationTime time.Duration `mapstructure:"max_accumulation_time"`
+	ProcessExemplars      bool          `mapstructure:"process_exemplars"`
+	SingleInstanceMode    bool          `mapstructure:"single_instance_mode"`
+	MaxAccumulationTime   time.Duration `mapstructure:"max_accumulation_time"`
+	WriteToLowestInstance bool          `mapstructure:"write_to_lowest_instance"`
 }
 
 // DefaultIngestionConfig returns default settings for ingestion.
 func DefaultIngestionConfig() IngestionConfig {
 	return IngestionConfig{
-		ProcessExemplars:    true,
-		SingleInstanceMode:  false,
-		MaxAccumulationTime: 10 * time.Second,
+		ProcessExemplars:      true,
+		SingleInstanceMode:    false,
+		MaxAccumulationTime:   10 * time.Second,
+		WriteToLowestInstance: false,
 	}
 }
 
@@ -253,8 +257,8 @@ func Load() (*Config, error) {
 			TenantID:         "",
 			ConnectionString: "",
 		},
-		Logs:   LogsConfig{},
-		Traces: TracesConfig{},
+		Logs:   LogsConfig{Ingestion: DefaultIngestionConfig()},
+		Traces: TracesConfig{Ingestion: DefaultIngestionConfig()},
 		Admin: AdminConfig{
 			InitialAPIKey: "",
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,9 +25,6 @@ func TestLoadEnvOverride(t *testing.T) {
 	t.Setenv("LAKERUNNER_FLY_SASL_ENABLED", "true")
 	t.Setenv("LAKERUNNER_FLY_SASL_USERNAME", "alice")
 	t.Setenv("LAKERUNNER_METRICS_INGESTION_PROCESS_EXEMPLARS", "false")
-	t.Setenv("LAKERUNNER_METRICS_INGESTION_WRITE_TO_LOWEST_INSTANCE", "true")
-	t.Setenv("LAKERUNNER_LOGS_INGESTION_WRITE_TO_LOWEST_INSTANCE", "true")
-	t.Setenv("LAKERUNNER_TRACES_INGESTION_WRITE_TO_LOWEST_INSTANCE", "true")
 
 	cfg, err := Load()
 	require.NoError(t, err)
@@ -36,18 +33,6 @@ func TestLoadEnvOverride(t *testing.T) {
 	require.True(t, cfg.Kafka.SASLEnabled)
 	require.Equal(t, "alice", cfg.Kafka.SASLUsername)
 	require.False(t, cfg.Metrics.Ingestion.ProcessExemplars)
-	require.True(t, cfg.Metrics.Ingestion.WriteToLowestInstance)
-	require.True(t, cfg.Logs.Ingestion.WriteToLowestInstance)
-	require.True(t, cfg.Traces.Ingestion.WriteToLowestInstance)
-}
-
-func TestDefaultWriteToLowestInstance(t *testing.T) {
-	cfg, err := Load()
-	require.NoError(t, err)
-
-	require.False(t, cfg.Metrics.Ingestion.WriteToLowestInstance)
-	require.False(t, cfg.Logs.Ingestion.WriteToLowestInstance)
-	require.False(t, cfg.Traces.Ingestion.WriteToLowestInstance)
 }
 
 func TestKafkaEnvarsOverFlyEnvars(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,9 @@ func TestLoadEnvOverride(t *testing.T) {
 	t.Setenv("LAKERUNNER_FLY_SASL_ENABLED", "true")
 	t.Setenv("LAKERUNNER_FLY_SASL_USERNAME", "alice")
 	t.Setenv("LAKERUNNER_METRICS_INGESTION_PROCESS_EXEMPLARS", "false")
+	t.Setenv("LAKERUNNER_METRICS_INGESTION_WRITE_TO_LOWEST_INSTANCE", "true")
+	t.Setenv("LAKERUNNER_LOGS_INGESTION_WRITE_TO_LOWEST_INSTANCE", "true")
+	t.Setenv("LAKERUNNER_TRACES_INGESTION_WRITE_TO_LOWEST_INSTANCE", "true")
 
 	cfg, err := Load()
 	require.NoError(t, err)
@@ -33,6 +36,18 @@ func TestLoadEnvOverride(t *testing.T) {
 	require.True(t, cfg.Kafka.SASLEnabled)
 	require.Equal(t, "alice", cfg.Kafka.SASLUsername)
 	require.False(t, cfg.Metrics.Ingestion.ProcessExemplars)
+	require.True(t, cfg.Metrics.Ingestion.WriteToLowestInstance)
+	require.True(t, cfg.Logs.Ingestion.WriteToLowestInstance)
+	require.True(t, cfg.Traces.Ingestion.WriteToLowestInstance)
+}
+
+func TestDefaultWriteToLowestInstance(t *testing.T) {
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	require.False(t, cfg.Metrics.Ingestion.WriteToLowestInstance)
+	require.False(t, cfg.Logs.Ingestion.WriteToLowestInstance)
+	require.False(t, cfg.Traces.Ingestion.WriteToLowestInstance)
 }
 
 func TestKafkaEnvarsOverFlyEnvars(t *testing.T) {

--- a/internal/metricsprocessing/logs_ingest_processor.go
+++ b/internal/metricsprocessing/logs_ingest_processor.go
@@ -69,7 +69,7 @@ func newLogIngestProcessor(
 	cfg *config.Config,
 	store LogIngestStore, storageProvider storageprofile.StorageProfileProvider, cmgr cloudstorage.ClientProvider, kafkaProducer fly.Producer) *LogIngestProcessor {
 	var exemplarProcessor *exemplars.Processor
-	if os.Getenv("DISABLE_EXEMPLARS") != "true" {
+	if cfg.Metrics.Ingestion.ProcessExemplars {
 		exemplarProcessor = exemplars.NewProcessor(exemplars.DefaultConfig())
 		exemplarProcessor.SetMetricsCallback(func(ctx context.Context, organizationID string, exemplars []*exemplars.ExemplarData) error {
 			return processLogsExemplarsDirect(ctx, organizationID, exemplars, store)
@@ -170,7 +170,7 @@ func (p *LogIngestProcessor) Process(ctx context.Context, group *accumulationGro
 	}
 
 	dstProfile := srcProfile
-	if p.config.Logs.Ingestion.WriteToLowestInstance {
+	if p.config.Logs.Ingestion.SingleInstanceMode {
 		dstProfile, err = p.storageProvider.GetLowestInstanceStorageProfile(ctx, srcProfile.OrganizationID, srcProfile.Bucket)
 		if err != nil {
 			return fmt.Errorf("get lowest instance storage profile: %w", err)

--- a/internal/metricsprocessing/logs_ingest_processor.go
+++ b/internal/metricsprocessing/logs_ingest_processor.go
@@ -159,12 +159,25 @@ func (p *LogIngestProcessor) Process(ctx context.Context, group *accumulationGro
 		}
 	}()
 
-	storageProfile, err := p.storageProvider.GetStorageProfileForOrganizationAndInstance(ctx, group.Key.OrganizationID, group.Key.InstanceNum)
+	srcProfile, err := p.storageProvider.GetStorageProfileForOrganizationAndInstance(ctx, group.Key.OrganizationID, group.Key.InstanceNum)
 	if err != nil {
 		return fmt.Errorf("get storage profile: %w", err)
 	}
 
-	storageClient, err := cloudstorage.NewClient(ctx, p.cmgr, storageProfile)
+	inputClient, err := cloudstorage.NewClient(ctx, p.cmgr, srcProfile)
+	if err != nil {
+		return fmt.Errorf("create storage client: %w", err)
+	}
+
+	dstProfile := srcProfile
+	if p.config.Logs.Ingestion.WriteToLowestInstance {
+		dstProfile, err = p.storageProvider.GetLowestInstanceStorageProfile(ctx, srcProfile.OrganizationID, srcProfile.Bucket)
+		if err != nil {
+			return fmt.Errorf("get lowest instance storage profile: %w", err)
+		}
+	}
+
+	outputClient, err := cloudstorage.NewClient(ctx, p.cmgr, dstProfile)
 	if err != nil {
 		return fmt.Errorf("create storage client: %w", err)
 	}
@@ -183,7 +196,7 @@ func (p *LogIngestProcessor) Process(ctx context.Context, group *accumulationGro
 			slog.String("objectID", msg.ObjectID),
 			slog.Int64("fileSize", msg.FileSize))
 
-		tmpFilename, _, is404, err := storageClient.DownloadObject(ctx, tmpDir, msg.Bucket, msg.ObjectID)
+		tmpFilename, _, is404, err := inputClient.DownloadObject(ctx, tmpDir, msg.Bucket, msg.ObjectID)
 		if err != nil {
 			ll.Error("Failed to download file", slog.String("objectID", msg.ObjectID), slog.Any("error", err))
 			continue // Skip this file but continue with others
@@ -222,7 +235,7 @@ func (p *LogIngestProcessor) Process(ctx context.Context, group *accumulationGro
 		return fmt.Errorf("failed to create unified reader: %w", err)
 	}
 
-	dateintBins, err := p.processRowsWithDateintBinning(ctx, finalReader, tmpDir, storageProfile)
+	dateintBins, err := p.processRowsWithDateintBinning(ctx, finalReader, tmpDir, srcProfile)
 	if err != nil {
 		return fmt.Errorf("failed to process rows: %w", err)
 	}
@@ -232,7 +245,7 @@ func (p *LogIngestProcessor) Process(ctx context.Context, group *accumulationGro
 		return nil
 	}
 
-	segmentParams, err := p.uploadAndCreateLogSegments(ctx, storageClient, dateintBins, storageProfile)
+	segmentParams, err := p.uploadAndCreateLogSegments(ctx, outputClient, dateintBins, dstProfile)
 	if err != nil {
 		return fmt.Errorf("failed to upload and create segments: %w", err)
 	}

--- a/internal/metricsprocessing/metric_ingest_processor.go
+++ b/internal/metricsprocessing/metric_ingest_processor.go
@@ -162,12 +162,25 @@ func (p *MetricIngestProcessor) Process(ctx context.Context, group *accumulation
 		}
 	}()
 
-	storageProfile, err := p.storageProvider.GetStorageProfileForOrganizationAndInstance(ctx, group.Key.OrganizationID, group.Key.InstanceNum)
+	srcProfile, err := p.storageProvider.GetStorageProfileForOrganizationAndInstance(ctx, group.Key.OrganizationID, group.Key.InstanceNum)
 	if err != nil {
 		return fmt.Errorf("get storage profile: %w", err)
 	}
 
-	storageClient, err := cloudstorage.NewClient(ctx, p.cmgr, storageProfile)
+	inputClient, err := cloudstorage.NewClient(ctx, p.cmgr, srcProfile)
+	if err != nil {
+		return fmt.Errorf("create storage client: %w", err)
+	}
+
+	dstProfile := srcProfile
+	if p.config.Metrics.Ingestion.WriteToLowestInstance {
+		dstProfile, err = p.storageProvider.GetLowestInstanceStorageProfile(ctx, srcProfile.OrganizationID, srcProfile.Bucket)
+		if err != nil {
+			return fmt.Errorf("get lowest instance storage profile: %w", err)
+		}
+	}
+
+	outputClient, err := cloudstorage.NewClient(ctx, p.cmgr, dstProfile)
 	if err != nil {
 		return fmt.Errorf("create storage client: %w", err)
 	}
@@ -186,7 +199,7 @@ func (p *MetricIngestProcessor) Process(ctx context.Context, group *accumulation
 			slog.String("objectID", msg.ObjectID),
 			slog.Int64("fileSize", msg.FileSize))
 
-		tmpFilename, _, is404, err := storageClient.DownloadObject(ctx, tmpDir, msg.Bucket, msg.ObjectID)
+		tmpFilename, _, is404, err := inputClient.DownloadObject(ctx, tmpDir, msg.Bucket, msg.ObjectID)
 		if err != nil {
 			ll.Error("Failed to download file", slog.String("objectID", msg.ObjectID), slog.Any("error", err))
 			continue // Skip this file but continue with others
@@ -228,7 +241,7 @@ func (p *MetricIngestProcessor) Process(ctx context.Context, group *accumulation
 	}
 
 	// Step 5-8: Process rows with time-based binning
-	timeBins, err := p.processRowsWithTimeBinning(ctx, finalReader, tmpDir, storageProfile)
+	timeBins, err := p.processRowsWithTimeBinning(ctx, finalReader, tmpDir, srcProfile)
 	if err != nil {
 		return fmt.Errorf("failed to process rows: %w", err)
 	}
@@ -238,7 +251,7 @@ func (p *MetricIngestProcessor) Process(ctx context.Context, group *accumulation
 		return nil
 	}
 
-	segmentParams, err := p.uploadAndCreateSegments(ctx, storageClient, timeBins, storageProfile)
+	segmentParams, err := p.uploadAndCreateSegments(ctx, outputClient, timeBins, dstProfile)
 	if err != nil {
 		return fmt.Errorf("failed to upload and create segments: %w", err)
 	}

--- a/internal/metricsprocessing/metric_ingest_processor.go
+++ b/internal/metricsprocessing/metric_ingest_processor.go
@@ -71,7 +71,7 @@ func newMetricIngestProcessor(
 	cfg *config.Config,
 	store MetricIngestStore, storageProvider storageprofile.StorageProfileProvider, cmgr cloudstorage.ClientProvider, kafkaProducer fly.Producer) *MetricIngestProcessor {
 	var exemplarProcessor *exemplars.Processor
-	if os.Getenv("DISABLE_EXEMPLARS") != "true" {
+	if cfg.Metrics.Ingestion.ProcessExemplars {
 		exemplarProcessor = exemplars.NewProcessor(exemplars.DefaultConfig())
 		exemplarProcessor.SetMetricsCallback(func(ctx context.Context, organizationID string, exemplars []*exemplars.ExemplarData) error {
 			return processMetricsExemplarsDirect(ctx, organizationID, exemplars, store)
@@ -173,7 +173,7 @@ func (p *MetricIngestProcessor) Process(ctx context.Context, group *accumulation
 	}
 
 	dstProfile := srcProfile
-	if p.config.Metrics.Ingestion.WriteToLowestInstance {
+	if p.config.Metrics.Ingestion.SingleInstanceMode {
 		dstProfile, err = p.storageProvider.GetLowestInstanceStorageProfile(ctx, srcProfile.OrganizationID, srcProfile.Bucket)
 		if err != nil {
 			return fmt.Errorf("get lowest instance storage profile: %w", err)

--- a/internal/metricsprocessing/trace_ingest_processor.go
+++ b/internal/metricsprocessing/trace_ingest_processor.go
@@ -186,7 +186,7 @@ func newTraceIngestProcessor(
 	cfg *config.Config,
 	store TraceIngestStore, storageProvider storageprofile.StorageProfileProvider, cmgr cloudstorage.ClientProvider, kafkaProducer fly.Producer) *TraceIngestProcessor {
 	var exemplarProcessor *exemplars.Processor
-	// if os.Getenv("DISABLE_EXEMPLARS") != "true" {
+	// if cfg.Traces.Ingestion.ProcessExemplars {
 	// 	exemplarProcessor = exemplars.NewProcessor(exemplars.DefaultConfig())
 	// 	exemplarProcessor.SetMetricsCallback(func(ctx context.Context, organizationID string, exemplars []*exemplars.ExemplarData) error {
 	// 		return processTracesExemplarsDirect(ctx, organizationID, exemplars, store)
@@ -289,7 +289,7 @@ func (p *TraceIngestProcessor) Process(ctx context.Context, group *accumulationG
 	}
 
 	dstProfile := srcProfile
-	if p.config.Traces.Ingestion.WriteToLowestInstance {
+	if p.config.Traces.Ingestion.SingleInstanceMode {
 		dstProfile, err = p.storageProvider.GetLowestInstanceStorageProfile(ctx, srcProfile.OrganizationID, srcProfile.Bucket)
 		if err != nil {
 			return fmt.Errorf("get lowest instance storage profile: %w", err)


### PR DESCRIPTION
## Summary
- add `write_to_lowest_instance` toggle for ingestion
- allow logs, metrics, traces to write output to lowest instance
- cover env overrides for new config options

## Testing
- `go test ./config -run TestDefaultWriteToLowestInstance -count=1`
- `go test ./internal/metricsprocessing -run TestNonExistent -count=1`
- `make check` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bd79810c8321a01efa5c646d7ff7