### PR TITLE
feat: add sweeper metrics

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -66,6 +66,8 @@ Many metrics include these standardized attributes:
 | `lakerunner.duckdb.memory.total_blocks` | DuckDB total blocks | 1 | - |
 | `lakerunner.duckdb.memory.used_blocks` | DuckDB used blocks | 1 | - |
 | `lakerunner.duckdb.memory.wal_size` | DuckDB WAL size | By | - |
+| `lakerunner.sweeper.cleanup_partitions_known` | Number of org-dateint combinations scheduled for cleanup | 1 | `signal` |
+| `lakerunner.sweeper.pack_estimate_target_records` | Target record estimates for pack tables | 1 | `signal`, `organization_id`, `frequency_ms` |
 | `lakerunner.exists` | Indicates if the service is running (1) or not (0) | - | - |
 
 ## Metric Groupings by Component

--- a/cmd/sweeper/cleanup_log_seg.go
+++ b/cmd/sweeper/cleanup_log_seg.go
@@ -124,6 +124,8 @@ func (w *LogCleanupWorkItem) Perform(ctx context.Context) time.Duration {
 		}
 	}
 
+	recordObjectCleanup(ctx, "log", s3DeletedCount, s3FailedCount)
+
 	// Execute database deletions using batch operation
 	dbDeletedCount := 0
 	if len(dbRecordsToDelete) > 0 {

--- a/cmd/sweeper/cleanup_metric_seg.go
+++ b/cmd/sweeper/cleanup_metric_seg.go
@@ -125,6 +125,8 @@ func (w *MetricCleanupWorkItem) Perform(ctx context.Context) time.Duration {
 		}
 	}
 
+	recordObjectCleanup(ctx, "metric", s3DeletedCount, s3FailedCount)
+
 	// Execute database deletions using batch operation
 	dbDeletedCount := 0
 	if len(dbRecordsToDelete) > 0 {

--- a/cmd/sweeper/cleanup_trace_seg.go
+++ b/cmd/sweeper/cleanup_trace_seg.go
@@ -124,6 +124,8 @@ func (w *TraceCleanupWorkItem) Perform(ctx context.Context) time.Duration {
 		}
 	}
 
+	recordObjectCleanup(ctx, "trace", s3DeletedCount, s3FailedCount)
+
 	// Execute database deletions using batch operation
 	dbDeletedCount := 0
 	if len(dbRecordsToDelete) > 0 {

--- a/cmd/sweeper/seg_cleanup.go
+++ b/cmd/sweeper/seg_cleanup.go
@@ -171,9 +171,12 @@ func (cm *CleanupManager) refreshPartitions(ctx context.Context, cdb configdb.Qu
 	// Update known dateints (this will mark deleted ones as unknown)
 	cm.knownDateints = newKnownDateints
 
+	total := len(newKnownDateints)
 	ll.Info("Refreshed partition list via discovery",
 		slog.String("signal_type", cm.signalType),
-		slog.Int("total_combinations", len(newKnownDateints)))
+		slog.Int("total_combinations", total))
+
+	recordPartitionCount(cm.signalType, total)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- track S3 object cleanup results and known cleanup partitions
- expose pack estimate target records as observable gauge
- document new sweeper gauges

## Testing
- `make fmt` *(fails: interrupted imports-fix)*
- `make check` *(fails: interrupted during test-only)*
- `go test ./cmd/sweeper -c`


------
https://chatgpt.com/codex/tasks/task_e_68c7bccc2c3883218cd1539a389f90f0