### PR TITLE
feat(duckdbx): add instance name metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.62.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/metric v1.37.0
+	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
@@ -636,7 +637,6 @@ require (
 	go.opentelemetry.io/otel/log v0.13.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.37.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.12.2 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/internal/duckdbx/duckdbx.go
+++ b/internal/duckdbx/duckdbx.go
@@ -41,6 +41,10 @@ type Config struct {
 	AzureExtension  string
 
 	pollerContext context.Context
+
+	// InstanceName, if set, is attached to emitted metrics to identify
+	// this DuckDB instance.
+	InstanceName string
 }
 
 type ExtensionConfig struct {
@@ -115,6 +119,13 @@ func WithMetrics(period time.Duration) option {
 func WithMetricsContext(ctx context.Context) option {
 	return func(c *Config) {
 		c.pollerContext = ctx
+	}
+}
+
+// WithName sets a name used to tag metrics for this DuckDB instance.
+func WithName(name string) option {
+	return func(c *Config) {
+		c.InstanceName = name
 	}
 }
 

--- a/internal/duckdbx/duckdbx_test.go
+++ b/internal/duckdbx/duckdbx_test.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 CardinalHQ, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package duckdbx
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestWithNameOption(t *testing.T) {
+	var cfg Config
+	WithName("foo")(&cfg)
+	require.Equal(t, "foo", cfg.InstanceName)
+}
+
+func TestPollMemoryMetricsRecordsInstanceName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	orig := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() { otel.SetMeterProvider(orig) })
+
+	db, err := Open(":memory:",
+		WithMetrics(10*time.Millisecond),
+		WithMetricsContext(ctx),
+		WithName("test-instance"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// allow poller to run at least once
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if g, ok := m.Data.(metricdata.Gauge[int64]); ok {
+				for _, dp := range g.DataPoints {
+					if v, ok := dp.Attributes.Value("instance_name"); ok && v.AsString() == "test-instance" {
+						found = true
+					}
+				}
+			}
+		}
+	}
+	require.True(t, found, "expected metric with instance_name attribute")
+}

--- a/internal/duckdbx/metrics.go
+++ b/internal/duckdbx/metrics.go
@@ -126,6 +126,9 @@ func (d *DB) pollMemoryMetrics(ctx context.Context) {
 				attribute.String("database_name", stat.DatabaseName),
 				attribute.String("database_type", "duckdb"),
 			}
+			if d.config.InstanceName != "" {
+				attributes = append(attributes, attribute.String("instance_name", d.config.InstanceName))
+			}
 			attr := metric.WithAttributeSet(attribute.NewSet(attributes...))
 			dbSizeGauge.Record(ctx, stat.DatabaseSize, attr)
 			blockSizeGauge.Record(ctx, stat.BlockSize, attr)


### PR DESCRIPTION
## Summary
- allow duckdb instances to be named
- include instance name on memory usage metrics
- test metric tagging

## Testing
- `make check` *(fails: create table: failed to get duckdb connection: failed to load extension 'httpfs': failed to install extension: IO Error: Failed to download extension "httpfs" at URL "http://extensions.duckdb.org/v1.3.2/linux_amd64/httpfs.duckdb_extension.gz"*

------
https://chatgpt.com/codex/tasks/task_e_68c7c2d9e0bc8321890767123c916aa0